### PR TITLE
Citation update

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,6 +3,9 @@ authors:
 - family-names: Ramirez
   given-names: Michelle
   orcid: "https://orcid.org/0009-0008-8162-5729"
+- family-names: Nepovinnykh
+  given-names: Ekaterina
+  orcid: "https://orcid.org/0000-0002-5045-5041"
 - family-names: Campolongo
   given-names: "Elizabeth G."
   orcid: "https://orcid.org/0000-0003-0846-2413"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,13 +11,6 @@ authors:
   orcid: "https://orcid.org/0000-0003-0846-2413"
 cff-version: 1.2.0
 date-released: "2024-08-12"
-identifiers:
-  - description: "The GitHub release URL of tag 1.0.0."
-    type: url
-    value: "https://github.com/Imageomics/2018-NEON-beetles-processing/releases/tag/v1.0.0"
-  - description: "The GitHub URL of the commit tagged with 1.0.0."
-    type: url
-    value: "https://github.com/Imageomics/2018-NEON-beetles-processing/tree/<commit-hash>" #update after relesase
 keywords:
   - imageomics
   - biology


### PR DESCRIPTION
Adds @kwadraterry to citation.

We won't make a release until we DOI the [dataset](https://huggingface.co/datasets/imageomics/2018-NEON-beetles), so also removed the identifiers indicating a release.