### PR TITLE
Generate functional metadata file for separate segmented split

### DIFF
--- a/notebooks/Separate_segmented_splits_meta_gen.ipynb
+++ b/notebooks/Separate_segmented_splits_meta_gen.ipynb
@@ -1,0 +1,544 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Get Metadata for [Separate_segmented_train_test_splits_80_20](https://huggingface.co/datasets/imageomics/2018-NEON-beetles/tree/main/Separate_segmented_train_test_splits_80_20)\n",
+    "\n",
+    "Using [`sum-buddy`](https://github.com/Imageomics/sum-buddy) package within the [2018-NEON-beetles repository](https://huggingface.co/datasets/imageomics/2018-NEON-beetles):\n",
+    "```\n",
+    "sum-buddy -o Separate_segmented_train_test_splits_80_20/checksum_metadata.csv Separate_segmented_train_test_splits_80_20\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>filepath</th>\n",
+       "      <th>filename</th>\n",
+       "      <th>md5</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Separate_segmented_train_test_splits_80_20/tes...</td>\n",
+       "      <td>beetle_1176_1088.png</td>\n",
+       "      <td>dcd4b79619ac96fd7519225f3bd46a86</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Separate_segmented_train_test_splits_80_20/tes...</td>\n",
+       "      <td>beetle_414_629.png</td>\n",
+       "      <td>3f388c96812cbfcf6036939eae49afe0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Separate_segmented_train_test_splits_80_20/tes...</td>\n",
+       "      <td>beetle_339_946.png</td>\n",
+       "      <td>df7b91b86ee4dc3b0ee8e8000f8b6e18</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Separate_segmented_train_test_splits_80_20/tes...</td>\n",
+       "      <td>beetle_130_537.png</td>\n",
+       "      <td>debd1c10ff568fd9ea48a025808cc324</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Separate_segmented_train_test_splits_80_20/tes...</td>\n",
+       "      <td>beetle_320_1374.png</td>\n",
+       "      <td>87d5a67d7f6ac04882ea9ab96e21272f</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                            filepath              filename  \\\n",
+       "0  Separate_segmented_train_test_splits_80_20/tes...  beetle_1176_1088.png   \n",
+       "1  Separate_segmented_train_test_splits_80_20/tes...    beetle_414_629.png   \n",
+       "2  Separate_segmented_train_test_splits_80_20/tes...    beetle_339_946.png   \n",
+       "3  Separate_segmented_train_test_splits_80_20/tes...    beetle_130_537.png   \n",
+       "4  Separate_segmented_train_test_splits_80_20/tes...   beetle_320_1374.png   \n",
+       "\n",
+       "                                md5  \n",
+       "0  dcd4b79619ac96fd7519225f3bd46a86  \n",
+       "1  3f388c96812cbfcf6036939eae49afe0  \n",
+       "2  df7b91b86ee4dc3b0ee8e8000f8b6e18  \n",
+       "3  debd1c10ff568fd9ea48a025808cc324  \n",
+       "4  87d5a67d7f6ac04882ea9ab96e21272f  "
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pd.read_csv(\"../../2018-NEON-beetles/Separate_segmented_train_test_splits_80_20/checksum_metadata.csv\")\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Make `split`, `species`, and `file_name` Columns\n",
+    "\n",
+    "`file_name` will be path within the `Separate_segmented_train_test_splits_80_20` for the dataset viewer on HF (and we'll name the file `metadata.csv` at that point)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(['Separate_segmented_train_test_splits_80_20/test/advena/beetle_1176_1088.png',\n",
+       "       'Separate_segmented_train_test_splits_80_20/test/advena/beetle_414_629.png',\n",
+       "       'Separate_segmented_train_test_splits_80_20/test/advena/beetle_339_946.png',\n",
+       "       'Separate_segmented_train_test_splits_80_20/test/advena/beetle_130_537.png',\n",
+       "       'Separate_segmented_train_test_splits_80_20/test/advena/beetle_320_1374.png',\n",
+       "       'Separate_segmented_train_test_splits_80_20/test/advena/beetle_749_1174.png',\n",
+       "       'Separate_segmented_train_test_splits_80_20/test/advena/beetle_754_788.png',\n",
+       "       'Separate_segmented_train_test_splits_80_20/test/advena/beetle_189_1137.png',\n",
+       "       'Separate_segmented_train_test_splits_80_20/test/advena/beetle_509_696.png',\n",
+       "       'Separate_segmented_train_test_splits_80_20/test/advena/beetle_137_238.png'],\n",
+       "      dtype=object)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[\"filepath\"].values[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_split(filepath):\n",
+    "    return filepath.split(\"/\")[1]\n",
+    "\n",
+    "def get_species(filepath):\n",
+    "    return filepath.split(\"/\")[2]\n",
+    "\n",
+    "def get_file_name(filepath):\n",
+    "    return filepath.split(\"splits_80_20/\")[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df[\"species\"] = df[\"filepath\"].apply(get_species)\n",
+    "df[\"split\"] = df[\"filepath\"].apply(get_split)\n",
+    "df[\"file_name\"] = df[\"filepath\"].apply(get_file_name)\n",
+    "\n",
+    "df[\"subset\"] = \"separate segmented splits\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>filepath</th>\n",
+       "      <th>filename</th>\n",
+       "      <th>md5</th>\n",
+       "      <th>species</th>\n",
+       "      <th>split</th>\n",
+       "      <th>file_name</th>\n",
+       "      <th>subset</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Separate_segmented_train_test_splits_80_20/tes...</td>\n",
+       "      <td>beetle_1176_1088.png</td>\n",
+       "      <td>dcd4b79619ac96fd7519225f3bd46a86</td>\n",
+       "      <td>advena</td>\n",
+       "      <td>test</td>\n",
+       "      <td>test/advena/beetle_1176_1088.png</td>\n",
+       "      <td>separate segmented splits</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Separate_segmented_train_test_splits_80_20/tes...</td>\n",
+       "      <td>beetle_414_629.png</td>\n",
+       "      <td>3f388c96812cbfcf6036939eae49afe0</td>\n",
+       "      <td>advena</td>\n",
+       "      <td>test</td>\n",
+       "      <td>test/advena/beetle_414_629.png</td>\n",
+       "      <td>separate segmented splits</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Separate_segmented_train_test_splits_80_20/tes...</td>\n",
+       "      <td>beetle_339_946.png</td>\n",
+       "      <td>df7b91b86ee4dc3b0ee8e8000f8b6e18</td>\n",
+       "      <td>advena</td>\n",
+       "      <td>test</td>\n",
+       "      <td>test/advena/beetle_339_946.png</td>\n",
+       "      <td>separate segmented splits</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Separate_segmented_train_test_splits_80_20/tes...</td>\n",
+       "      <td>beetle_130_537.png</td>\n",
+       "      <td>debd1c10ff568fd9ea48a025808cc324</td>\n",
+       "      <td>advena</td>\n",
+       "      <td>test</td>\n",
+       "      <td>test/advena/beetle_130_537.png</td>\n",
+       "      <td>separate segmented splits</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Separate_segmented_train_test_splits_80_20/tes...</td>\n",
+       "      <td>beetle_320_1374.png</td>\n",
+       "      <td>87d5a67d7f6ac04882ea9ab96e21272f</td>\n",
+       "      <td>advena</td>\n",
+       "      <td>test</td>\n",
+       "      <td>test/advena/beetle_320_1374.png</td>\n",
+       "      <td>separate segmented splits</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                            filepath              filename  \\\n",
+       "0  Separate_segmented_train_test_splits_80_20/tes...  beetle_1176_1088.png   \n",
+       "1  Separate_segmented_train_test_splits_80_20/tes...    beetle_414_629.png   \n",
+       "2  Separate_segmented_train_test_splits_80_20/tes...    beetle_339_946.png   \n",
+       "3  Separate_segmented_train_test_splits_80_20/tes...    beetle_130_537.png   \n",
+       "4  Separate_segmented_train_test_splits_80_20/tes...   beetle_320_1374.png   \n",
+       "\n",
+       "                                md5 species split  \\\n",
+       "0  dcd4b79619ac96fd7519225f3bd46a86  advena  test   \n",
+       "1  3f388c96812cbfcf6036939eae49afe0  advena  test   \n",
+       "2  df7b91b86ee4dc3b0ee8e8000f8b6e18  advena  test   \n",
+       "3  debd1c10ff568fd9ea48a025808cc324  advena  test   \n",
+       "4  87d5a67d7f6ac04882ea9ab96e21272f  advena  test   \n",
+       "\n",
+       "                          file_name                     subset  \n",
+       "0  test/advena/beetle_1176_1088.png  separate segmented splits  \n",
+       "1    test/advena/beetle_414_629.png  separate segmented splits  \n",
+       "2    test/advena/beetle_339_946.png  separate segmented splits  \n",
+       "3    test/advena/beetle_130_537.png  separate segmented splits  \n",
+       "4   test/advena/beetle_320_1374.png  separate segmented splits  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "species\n",
+       "advena                   1355\n",
+       "impunctatus              1139\n",
+       "goryi                    1096\n",
+       "lachrymosus               613\n",
+       "torvus                    490\n",
+       "pensylvanicus             451\n",
+       "melanarius melanarius     380\n",
+       "restrictus                347\n",
+       "aestivus                  336\n",
+       "melanarius                292\n",
+       "grossus                   289\n",
+       "dubius                    282\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.species.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Display Distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import seaborn as sns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Axes: xlabel='Count', ylabel='species'>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsAAAAGwCAYAAACn5dOzAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8g+/7EAAAACXBIWXMAAA9hAAAPYQGoP6dpAABrgklEQVR4nO3deVxV1f7/8ddBmUcVFCyGUFEIHJAsMZUcyyHNck4jS+0mlplpXmfN4VpmaTZ5S8y5UsnMTDMxcxZEK1EcENToOqSgaA5wfn/45fw6IgqIHOW8n4/HfsTZe+21PnuZ8mGx9loGo9FoRERERETESthYOgARERERkdKkBFhERERErIoSYBERERGxKkqARURERMSqKAEWEREREauiBFhERERErIoSYBERERGxKuUtHYDI3SY3N5c//vgDV1dXDAaDpcMRERGRQjAajZw7d46qVatiY3PzMV4lwCLX+eOPP/D19bV0GCIiIlIMR48e5f77779pGSXAItdxdXUFrv0FcnNzs3A0IiIiUhhZWVn4+vqavo/fjBJgkevkTXtwc3NTAiwiInKPKcz0Rb0EJyIiIiJWRQmwiIiIiFgVJcAiIiIiYlWUAIuIiIiIVVECLCIiIiJWRQmwiIiIiFgVJcAiIiIiYlWUAIuIiIiIVVECLCIiIiJWRQmwiIiIiFgVJcAiIiIiYlWUAIuIiIiIVVECLCIiIiJWpbylAxC5Wy1ZsgQnJydLhyElwMPDAx8fH0uHISIigKenJ35+fhaNwWA0Go0WjUDkLpOVlYW7u7ulwxARESmTnJwcSU7eV+JJcN7378zMTNzc3G5aViPAIgWIfLwj1asHWjoMuU2nT5zguy/nM//fXQj287J0OCIiVi05/STPTvqSU6dOWXQUWAmwSAH8/O6jbu0HLR2G3KZjaS58BwT7eREedJ+lwxERkbuAXoITEREREauiBFhERERErIoSYBERERGxKkqARURERMSqKAEWEREREauiBFhERERErIoSYLljjhw5gsFgICkpydKhiIiIiJgoARYRERERq6IEWERERESsihJgKbTVq1fz6KOP4uHhQaVKlWjXrh2HDh0yXd++fTv16tXDwcGBiIgIdu3aZbqWm5vL/fffz8cff2xWZ2JiIgaDgcOHDwOQmZlJv379qFy5Mm5ubjRr1ozdu3ebyo8dO5a6desyb948AgICcHd3p1u3bpw7d67QcYqIiIh1UwIshZadnc3gwYPZsWMH69atw8bGhqeeeorc3Fyys7Np164dNWvWJCEhgbFjxzJkyBDTvTY2NnTr1o0FCxaY1blw4UIaNmxIYGAgRqORtm3b8ueff7Jq1SoSEhIIDw+nefPm/PXXX6Z7Dh06RFxcHCtXrmTlypVs2LCBKVOmFCrOG7l06RJZWVlmh4iIiJRd5S0dgNw7nn76abPPn332GZUrV2bv3r1s3ryZnJwcPv/8c5ycnHjwwQc5duwY//rXv0zle/bsybvvvktaWhr+/v7k5uayePFi/v3vfwOwfv16fv31V06cOIG9vT0A77zzDnFxcXz99df069cPuDaaHBsbi6urKwC9evVi3bp1TJw48ZZxhoaG5nuuyZMnM27cuBLqJREREbnbaQRYCu3QoUP06NGDwMBA3NzceOCBBwBIT08nOTmZOnXq4OTkZCrfsGFDs/vr1atHrVq1WLRoEQAbNmzgxIkTdOnSBYCEhATOnz9PpUqVcHFxMR2pqalmUxgCAgJMyS+Aj48PJ06cKFScNzJ8+HAyMzNNx9GjR2+nm0REROQupxFgKbT27dvj6+vL7NmzqVq1Krm5uYSGhnL58mWMRmOh6ujZsycLFy7kzTffZOHChbRu3RpPT0/g2siuj48P8fHx+e7z8PAwfW1ra2t2zWAwmE1vuFmcN2Jvb28acRYREZGyTwmwFMrp06dJTk7mk08+oXHjxgD88ssvpushISHMmzePixcv4ujoCMDWrVvz1dOjRw9GjhxJQkICX3/9NR999JHpWnh4OH/++Sfly5cnICDgjsQpIiIioikQUigVKlSgUqVKfPrppxw8eJCffvqJwYMHm6736NEDGxsbXnjhBfbu3cuqVat455138tXzwAMPEBkZyQsvvMDVq1fp0KGD6VqLFi1o2LAhHTt25IcffuDIkSNs3ryZkSNHsnPnzhKJU0REREQJsBSKjY0NixcvJiEhgdDQUF577TXefvtt03UXFxe+/fZb9u7dS7169RgxYgT/+c9/blhXz5492b17N506dTKNFsO1qQyrVq2iSZMm9OnTh6CgILp168aRI0eoUqVKicQpIiIiYjAWdvKmiJXIysq6tr5wvwE0iAi3dDhym46lpfHuxPEkfDyA8KD7LB2OiIhVS0w5Tv2XZpmWOi1Jed+/MzMzcXNzu2lZjQCLiIiIiFVRAiwiIiIiVkUJsIiIiIhYFSXAIiIiImJVlACLiIiIiFVRAiwiIiIiVkU7wYkUIDEhieMZJyzStp29A04urhZpu6y5kPkXAMnpJy0ciYiI3C3/FmsdYJHr5K0jKCIiIiXPycmR5OR9+Pn5lWi9RVkHWCPAIgUIbdyKqr6+pd5u1l+n2Lr6G4Z2fhhfr5v/BZabO3byHP/5aivvvfcejRs3tnQ4IiICeHp6lnjyW1RKgEUKEBpcwyI7wR1LS2Pr6m/o2jxCO5fdpsSU4/znq600bty4xHccEhGRe5deghMRERERq6IEWERERESsihJgEREREbEqSoBFRERExKooARYRERERq6IEWERERESsihJguSsYDAbi4uIsHYaIiIhYASXAUqrGjh1L3bp1853PyMjgiSeeKP2ARERExOpoIwy5K3h7e1s6BBEREbESGgGWfFavXs2jjz6Kh4cHlSpVol27dhw6dMh0/fjx43Tt2pUKFSpQqVIlOnTowJEjR0zX4+PjadCgAc7Oznh4eNCoUSPS0tKIjY1l3Lhx7N69G4PBgMFgIDY2FjCfAtGwYUPefPNNs5hOnjyJra0t69evz1c+j4eHh6m+y5cvExMTg4+PDw4ODgQEBDB58uQS7ScRERG5NykBlnyys7MZPHgwO3bsYN26ddjY2PDUU0+Rm5vLhQsXeOyxx3BxceHnn3/ml19+wcXFhccff5zLly9z9epVOnbsSNOmTdmzZw9btmyhX79+GAwGunbtyuuvv86DDz5IRkYGGRkZdO3aNV/7PXv2ZNGiRRiNRtO5JUuWUKVKFZo2bVqoZ5gxYwYrVqzgyy+/ZP/+/cyfP5+AgIAblr106RJZWVlmh4iIiJRdmgIh+Tz99NNmnz/77DMqV67M3r172b59OzY2Nvz3v//FYDAAMGfOHDw8PIiPjyciIoLMzEzatWtHtWrVAAgODjbV5eLiQvny5W865aFr16689tpr/PLLLzRu3BiAhQsX0qNHD2xsCvczW3p6OjVq1ODRRx/FYDDg7+9fYNnJkyczbty4QtUrIiIi9z6NAEs+hw4dokePHgQGBuLm5sYDDzwAXEsqExISOHjwIK6urri4uODi4kLFihX5+++/OXToEBUrViQ6OprWrVvTvn173n//fTIyMorUvpeXFy1btmTBggUApKamsmXLFnr27FnoOqKjo0lKSqJmzZq88sorrFmzpsCyw4cPJzMz03QcPXq0SPGKiIjIvUUJsOTTvn17Tp8+zezZs9m2bRvbtm0Drs2rzc3NpX79+iQlJZkdKSkp9OjRA7g2IrxlyxYiIyNZsmQJQUFBbN26tUgx9OzZk6+//porV66wcOFCHnzwQerUqWO6bjAYzKZIAFy5csX0dXh4OKmpqUyYMIGLFy/SpUsXnnnmmRu2ZW9vj5ubm9khIiIiZZcSYDFz+vRpkpOTGTlyJM2bNyc4OJgzZ86YroeHh3PgwAEqV65M9erVzQ53d3dTuXr16jF8+HA2b95MaGgoCxcuBMDOzo6cnJxbxtGxY0f+/vtvVq9ezcKFC3n22WfNrnt5eZmNLB84cIALFy6YlXFzc6Nr167Mnj2bJUuWsHTpUv76669i9YuIiIiUHUqAxUzeyg6ffvopBw8e5KeffmLw4MGm6z179sTT05MOHTqwceNGUlNT2bBhA6+++irHjh0jNTWV4cOHs2XLFtLS0lizZg0pKSmmecABAQGkpqaSlJTEqVOnuHTp0g3jcHZ2pkOHDowaNYrk5GTT6HKeZs2a8cEHH5CYmMjOnTt56aWXsLW1NV2fPn06ixcvZt++faSkpPDVV1/h7e2Nh4dHyXeaiIiI3FOUAIsZGxsbFi9eTEJCAqGhobz22mu8/fbbputOTk78/PPP+Pn50alTJ4KDg+nTpw8XL17Ezc0NJycn9u3bx9NPP01QUBD9+vUjJiaG/v37A9desHv88cd57LHH8PLyYtGiRQXG0rNnT3bv3k3jxo3x8/MzuzZt2jR8fX1p0qQJPXr0YMiQITg5OZmuu7i48J///IeIiAgeeughjhw5wqpVqwr9Ep2IiIiUXQbj9RMpRaxcVlYW7u7udOs3gAYR4aXe/rG0NN6dOJ6EjwcQHnRfqbdfliSmHKf+S7NISEggPLz0/yxFRKT05H3/zszMvOX7PBoOExERERGrogRYRERERKyKEmARERERsSpKgEVERETEqigBFhERERGrogRYRERERKxKeUsHIHK3SkxI4njGiTvahp29A04urmbnMk+fBGDV9hSS00/e0fbvZh4uDvhUdL11wZuw5v4TEZGCaR1gkevkrSMolmUASuIfJycnR5KT9+XbTEVERMqWoqwDrBFgkQKENm5FVV/fO1Z/1l+n2Lr6G4Z2fhhfL/O/qO5O9lT2cL5jbd/tDv5xhpgP1zB//nzTNtrF5enpqeRXRETMKAEWKUBocI07uhPcsbQ0tq7+hq7NI7Tj23W8Uo4DawgODtYObiIiUuL0EpyIiIiIWBUlwCIiIiJiVZQAi4iIiIhVUQIsIiIiIlZFCbCIiIiIWBUlwCIiIiJiVZQAS4mLiopi0KBBhSp75MgRDAYDSUlJBZaJj4/HYDBw9uzZEolPRERErJsSYLnrRUZGkpGRod3ZREREpERoIwy569nZ2eHt7W3pMERERKSM0Aiw3Jbs7Gx69+6Ni4sLPj4+TJs2zey6wWAgLi7O7JyHhwexsbFm5/bt20dkZCQODg48+OCDxMfHm65dPwVi7Nix1K1b1+z+9957j4CAALN7GjRogLOzMx4eHjRq1Ii0tLTbfFoREREpC5QAy2154403WL9+PcuXL2fNmjXEx8eTkJBQrHpef/11du3aRWRkJE8++SSnT58uVkxXr16lY8eONG3alD179rBlyxb69euHwWC4YflLly6RlZVldoiIiEjZpQRYiu38+fN89tlnvPPOO7Rs2ZKwsDDmzp1LTk5OkeuKiYnh6aefJjg4mI8++gh3d3c+++yzYsWVlZVFZmYm7dq1o1q1agQHB/Pcc8/h5+d3w/KTJ0/G3d3ddPj6+harXREREbk3KAGWYjt06BCXL1+mYcOGpnMVK1akZs2aRa7rn3WUL1+eiIgIkpOTixVXxYoViY6OpnXr1rRv357333+fjIyMAssPHz6czMxM03H06NFitSsiIiL3BiXAUmxGo/GWZQwGQ75yV65cKVT9BU1ZsLGxuWWdc+bMYcuWLURGRrJkyRKCgoLYunXrDeuzt7fHzc3N7BAREZGySwmwFFv16tWxtbU1SyzPnDlDSkqK6bOXl5fZ6OuBAwe4cOFCvrr+WcfVq1dJSEigVq1aN2zXy8uLP//80ywJvtE6wvXq1WP48OFs3ryZ0NBQFi5cWKTnExERkbJJy6BJsbm4uPDCCy/wxhtvUKlSJapUqcKIESOwsfn/P1c1a9aMDz74gEceeYTc3FyGDRuGra1tvrpmzZpFjRo1CA4OZvr06Zw5c4Y+ffrcsN2oqChOnjzJ1KlTeeaZZ1i9ejXff/+9aeQ2NTWVTz/9lCeffJKqVauyf/9+UlJS6N27953pCBEREbmnaARYbsvbb79NkyZNePLJJ2nRogWPPvoo9evXN12fNm0avr6+NGnShB49ejBkyBCcnJzy1TNlyhT+85//UKdOHTZu3Mg333yDp6fnDdsMDg7mww8/ZNasWdSpU4ft27czZMgQ03UnJyf27dvH008/TVBQEP369SMmJob+/fuXfAeIiIjIPcdgLMxEThErkpWVhbu7O936DaBBRPgda+dYWhrvThxPwscDCA+67461cy9KTDlO/ZdmkZCQQHj4nfszEBGRsiPv+3dmZuYt3+fRCLCIiIiIWBUlwCIiIiJiVZQAi4iIiIhVUQIsIiIiIlZFCbCIiIiIWBUlwCIiIiJiVbQRhkgBEhOSOJ5x4o7Vf/7sGQD+u2onVben3KK09XB1tOPcxcsAJCcnWzgaEbEGnp6e+Pn5WToMKUVaB1jkOnnrCIqIiHVwcnIkOXmfkuB7XFHWAdYIsEgBQhu3oqqv7x1tw758ORzt9Ncwz1+nTvJj3FfMfLklYYFVcXVxsXRIIlLGJaef5NlJX3Lq1CklwFZE33lFChAaXOOO7gQn+R1LS+PHOIisHaTd8URE5I7RS3AiIiIiYlWUAIuIiIiIVVECLCIiIiJWRQmwiIiIiFgVJcAiIiIiYlWUAIuIiIiIVVECLGVebGwsHh4elg5DRERE7hJKgKXM69q1Kykp2mpYRERErtFGGHLPysnJwWAwYGNz85/jHB0dcXR0LKWoRERE5G6nEWApNefOnaNnz544Ozvj4+PD9OnTiYqKYtCgQQCcOXOG3r17U6FCBZycnHjiiSc4cOCA6f68qQwrV64kJCQEe3t7Nm7ciK2tLX/++adZW6+//jpNmjQxu09EREQElABLKRo8eDCbNm1ixYoVrF27lo0bN5KYmGi6Hh0dzc6dO1mxYgVbtmzBaDTSpk0brly5Yipz4cIFJk+ezH//+19+//13IiIiCAwMZN68eaYyV69eZf78+Tz//POFiuvSpUtkZWWZHSIiIlJ2KQGWUnHu3Dnmzp3LO++8Q/PmzQkNDWXOnDnk5OQAcODAAVasWMF///tfGjduTJ06dViwYAHHjx8nLi7OVM+VK1f48MMPiYyMpGbNmjg7O/PCCy8wZ84cU5nvvvuOCxcu0KVLl0LFNnnyZNzd3U2Hr69viT67iIiI3F2UAEupOHz4MFeuXKFBgwamc+7u7tSsWROA5ORkypcvz8MPP2y6XqlSJWrWrElycrLpnJ2dHbVr1zarOzo6moMHD7J161YAPv/8c7p06YKzs3OhYhs+fDiZmZmm4+jRo8V+ThEREbn76SU4KRVGoxEAg8Fww/N5/73Rff+8x9HRMV8dlStXpn379syZM4fAwEBWrVpFfHx8oWOzt7fH3t6+0OVFRETk3qYRYCkV1apVw9bWlu3bt5vOZWVlmV5yCwkJ4erVq2zbts10/fTp06SkpBAcHHzL+l988UUWL17MJ598QrVq1WjUqFHJP4SIiIiUCUqApVS4urry3HPP8cYbb7B+/Xp+//13+vTpg42NDQaDgRo1atChQwf69u3LL7/8wu7du3n22We577776NChwy3rb926Ne7u7rz11luFfvlNRERErJMSYCk17777Lg0bNqRdu3a0aNGCRo0aERwcjIODAwBz5syhfv36tGvXjoYNG2I0Glm1ahW2tra3rNvGxobo6GhycnLo3bv3nX4UERERuYcpAZZS4+rqyoIFC8jOziYjI4N+/fqxf/9+qlevDkCFChX44osvOHv2LBcuXGD16tXUqFHDdH90dDRnz54tsP6MjAzatGmDj4+P2flb3SciIiLWRS/BSanZtWsX+/bto0GDBmRmZjJ+/HiAQk1xuJnMzEx27NjBggUL+Oabb0oiVBERESnDlABLqXrnnXfYv38/dnZ21K9fn40bN+Lp6XlbdXbo0IHt27fTv39/WrZsWUKRioiISFmlBFhKTb169UhISCjxeouy5JmIiIiI5gCLiIiIiFVRAiwiIiIiVkUJsIiIiIhYFc0BFilAYkISxzNOlEhddvYOOLm4lkhdZVnm6ZMArNqeQnL6yVuW93BxwKei+lVEiq8w/9ZI2WMwGo1GSwchcjfJysrC3d3d0mFIIRgA/QMmIrfLycmR5OR9+Pn5WToUuQ15378zMzNxc3O7aVmNAIsUILRxK6r6+t52PVl/nWLr6m8Y2vlhfL1u/hdSwN3Jnsoezrcsd/CPM8R8uIb58+cTHBxcCpGJSFnl6emp5NfKKAEWKUBocA0aRITfdj3H0tLYuvobujaPIDzovhKITAC8Uo4DawgODiY8/Pb/nERExHroJTgRERERsSpKgEVERETEqigBFhERERGrogRYRERERKyKEmARERERsSpKgEVERETEqigBFhERERGrogRYRERERKyKEmApcZcvX7Z0CCIiIiIFUgIst3Tu3Dl69uyJs7MzPj4+TJ8+naioKAYNGgRAQEAAb731FtHR0bi7u9O3b18Ali5dyoMPPoi9vT0BAQFMmzbNrN4PP/yQGjVq4ODgQJUqVXjmmWdM177++mvCwsJwdHSkUqVKtGjRguzsbACztvN07NiR6OjoQtUtIiIi1k1bIcstDR48mE2bNrFixQqqVKnC6NGjSUxMpG7duqYyb7/9NqNGjWLkyJEAJCQk0KVLF8aOHUvXrl3ZvHkzL7/8MpUqVSI6OpqdO3fyyiuvMG/ePCIjI/nrr7/YuHEjABkZGXTv3p2pU6fy1FNPce7cOTZu3IjRaCxUvDer+0YuXbrEpUuXTJ+zsrKK0UsiIiJyr1ACLDd17tw55s6dy8KFC2nevDkAc+bMoWrVqmblmjVrxpAhQ0yfe/bsSfPmzRk1ahQAQUFB7N27l7fffpvo6GjS09NxdnamXbt2uLq64u/vT7169YBrCfDVq1fp1KkT/v7+AISFhRU65pvVfSOTJ09m3Lhxha5fRERE7m2aAiE3dfjwYa5cuUKDBg1M59zd3alZs6ZZuYiICLPPycnJNGrUyOxco0aNOHDgADk5ObRs2RJ/f38CAwPp1asXCxYs4MKFCwDUqVOH5s2bExYWRufOnZk9ezZnzpwpdMw3q/tGhg8fTmZmpuk4evRoodsSERGRe48SYLmpvGkHBoPhhufzODs757t+s3tcXV1JTExk0aJF+Pj4MHr0aOrUqcPZs2cpV64ca9eu5fvvvyckJISZM2dSs2ZNUlNTAbCxscnX/pUrVwpV943Y29vj5uZmdoiIiEjZpQRYbqpatWrY2tqyfft207msrCwOHDhw0/tCQkL45ZdfzM5t3ryZoKAgypUrB0D58uVp0aIFU6dOZc+ePRw5coSffvoJuJZwN2rUiHHjxrFr1y7s7OxYvnw5AF5eXmRkZJjqzcnJ4bfffjNr62Z1i4iIiHXTHGC5KVdXV5577jneeOMNKlasSOXKlRkzZgw2Njb5Rnj/6fXXX+ehhx5iwoQJdO3alS1btvDBBx/w4YcfArBy5UoOHz5MkyZNqFChAqtWrSI3N5eaNWuybds21q1bR6tWrahcuTLbtm3j5MmTBAcHA9fmGw8ePJjvvvuOatWqMX36dLPR3ZvVLSIiIqIEWG7p3Xff5aWXXqJdu3a4ubkxdOhQjh49ioODQ4H3hIeH8+WXXzJ69GgmTJiAj48P48ePNy1V5uHhwbJlyxg7dix///03NWrUYNGiRTz44IMkJyfz888/895775GVlYW/vz/Tpk3jiSeeAKBPnz7s3r2b3r17U758eV577TUee+wxU9s3q1tERETEYCzs2lIi/yc7O5v77ruPadOm8cILL1g6nBKXlZWFu7s73foNoEFE+G3XdywtjXcnjifh4wGEB91XAhEKQGLKceq/NIuEhATCw2//z0lERO5ted+/MzMzb/k+j0aA5ZZ27drFvn37aNCgAZmZmYwfPx6ADh06WDgyERERkaJTAiyF8s4777B//37s7OyoX78+GzduxNPT09JhiYiIiBSZEmC5pXr16pGQkGDpMERERERKhJZBExERERGrogRYRERERKyKEmARERERsSqaAyxSgMSEJI5nnLjtes6fPQPAf1ftpOr2lNuur6xzdbTD0935luVS/7zWr8nJyXc6JBGRIvH09MTPz8/SYchNaB1gkevkrSMoIiJSHE5OjiQn71MSXMq0DrBICQht3Iqqvr4lUpd9+XI42umv2638deokP8Z9xcyXW1KjasVblndwcMDVxaUUIhMRKZzk9JM8O+lLTp06pQT4LqbvyCIFCA2uUSI7wUnhHUtL48c4iKwdpF3zRETkjtFLcCIiIiJiVZQAi4iIiIhVUQIsIiIiIlalWAnw3Llz+e6770yfhw4dioeHB5GRkaSlpZVYcCIiIiIiJa1YCfCkSZNwdHQEYMuWLXzwwQdMnToVT09PXnvttRINUERERESkJBVrFYijR49SvXp1AOLi4njmmWfo168fjRo1IioqqiTjExEREREpUcUaAXZxceH06dMArFmzhhYtWgDX1uS8ePFiyUVn5aKiohg0aJClwxAREREpU4qVALds2ZIXX3yRF198kZSUFNq2bQvA77//TkBAQEnGZ9WWLVvGhAkTLB3GbYuNjcXDw6PI98XHx2MwGDh79myJxyQiIiLWq1gJ8KxZs2jYsCEnT55k6dKlVKpUCYCEhAS6d+9eogFas4oVK+Lq6mrpMERERETKlGIlwB4eHnzwwQd88803PP7446bz48aNY8SIESUWnLX75xSIgIAA3nrrLXr37o2Liwv+/v588803nDx5kg4dOuDi4kJYWBg7d+403Z838hoXF0dQUBAODg60bNmSo0ePmspER0fTsWNHs3YHDRpkNpc7KiqKV155haFDh1KxYkW8vb0ZO3as2T1nz56lX79+VKlSBQcHB0JDQ1m5ciXx8fE8//zzZGZmYjAYMBgMpnvnz59PREQErq6ueHt706NHD06cOAHAkSNHeOyxxwCoUKECBoOB6OhoU1+89957Zu3XrVvXLKaxY8fi5+eHvb09VatW5ZVXXila54uIiEiZVex1gDdu3Mizzz5LZGQkx48fB2DevHn88ssvJRacmJs+fTqNGjVi165dtG3bll69etG7d2+effZZEhMTqV69Or1798ZoNJruuXDhAhMnTmTu3Lls2rSJrKwsunXrVuS2586di7OzM9u2bWPq1KmMHz+etWvXApCbm8sTTzzB5s2bmT9/Pnv37mXKlCmUK1eOyMhI3nvvPdzc3MjIyCAjI4MhQ4YAcPnyZSZMmMDu3buJi4sjNTXVlOT6+vqydOlSAPbv309GRgbvv/9+oWL9+uuvmT59Op988gkHDhwgLi6OsLCwAstfunSJrKwss0NERETKrmKtArF06VJ69epFz549SUxM5NKlSwCcO3eOSZMmsWrVqhINUq5p06YN/fv3B2D06NF89NFHPPTQQ3Tu3BmAYcOG0bBhQ/73v//h7e0NwJUrV/jggw94+OGHgWuJbHBwMNu3b6dBgwaFbrt27dqMGTMGgBo1avDBBx+wbt06WrZsyY8//sj27dtJTk4mKCgIgMDAQNO97u7uGAwGU0x5+vTpY/o6MDCQGTNm0KBBA86fP4+LiwsVK1YEoHLlykWaQ5yeno63tzctWrTA1tYWPz+/mz7r5MmTGTduXKHrFxERkXtbsUaA33rrLT7++GNmz56Nra2t6XxkZCSJiYklFpyYq127tunrKlWqAJiNbOady5tGAFC+fHkiIiJMn2vVqoWHhwfJycnFbhvAx8fH1E5SUhL333+/KfktrF27dtGhQwf8/f1xdXU1TbtIT08vUj3X69y5MxcvXiQwMJC+ffuyfPlyrl69WmD54cOHk5mZaTr+OUVEREREyp5iJcD79++nSZMm+c67ubnpjf076J8/bBgMhgLP5ebmmt2Xd/5G52xsbMymTMC1UeObtZ13f147eZuiFEV2djatWrXCxcWF+fPns2PHDpYvXw5cmxpxM7eK2dfXl/379zNr1iwcHR15+eWXadKkyQ2fC8De3h43NzezQ0RERMquYiXAPj4+HDx4MN/5X375xexX32J5V69eNXsxbv/+/Zw9e5ZatWoB4OXlRUZGhtk9SUlJRWqjdu3aHDt2jJSUlBtet7OzIycnx+zcvn37OHXqFFOmTKFx48bUqlXLbOQ67z4g373Xx5yVlUVqaqpZGUdHR5588klmzJhBfHw8W7Zs4ddffy3Sc4mIiEjZVKwEuH///rz66qts27YNg8HAH3/8wYIFCxgyZAgvv/xySccot8HW1paBAweybds2EhMTef7553nkkUdMc2KbNWvGzp07+eKLLzhw4ABjxozht99+K1IbTZs2pUmTJjz99NOsXbuW1NRUvv/+e1avXg1cW7Xh/PnzrFu3jlOnTnHhwgX8/Pyws7Nj5syZHD58mBUrVuRb89jf3x+DwcDKlSs5efIk58+fN8U8b948Nm7cyG+//cZzzz1HuXLlTPfFxsby2Wef8dtvv3H48GHmzZuHo6Mj/v7+t9OVIiIiUkYUKwEeOnQoHTt25LHHHuP8+fM0adKEF198kf79+xMTE1PSMcptcHJyYtiwYfTo0YOGDRvi6OjI4sWLTddbt27NqFGjGDp0KA899BDnzp2jd+/eRW5n6dKlPPTQQ3Tv3p2QkBCGDh1qGrmNjIzkpZdeomvXrnh5eTF16lS8vLyIjY3lq6++IiQkhClTpvDOO++Y1Xnfffcxbtw43nzzTapUqWL6f2v48OE0adKEdu3a0aZNGzp27Ei1atVM93l4eDB79mwaNWpE7dq1WbduHd9++61pvWoRERGxbgbj9ZMpi+DChQvs3buX3NxcQkJCcHFxKcnY5DbFxsYyaNAgzcsuoqysLNzd3enWbwANIsItHY5VOZaWxrsTx5Pw8QDCg+6zdDgiIkWWmHKc+i/NIiEhgfBwfQ8pTXnfvzMzM2/5Pk+xlkHL4+TkZLbCgIiIiIjI3a7QCXCnTp2IjY3Fzc2NTp063bTssmXLbjswEREREZE7odAJcN5mBnlfy90vOjratLOaiIiIiFxT6AR4zpw5N/xaREREROReUqxVIFJTUzlw4EC+8wcOHODIkSO3G5OIiIiIyB1TrAQ4OjqazZs35zu/bds2/cpdRERERO5qxVoFYteuXTRq1Cjf+UceeUTrAEuZkZiQxPGME7cueI+xs3fAycXV0mHcUObpkwCs2p5CcvpJC0cjJcXDxQGfinfn/3MiJU3/dt0bipUAGwwGzp07l+98ZmZmvm1rRe5VKQmbSEmwdBTWadTnay0dgpQgA1DsBedF7kFOTo54enpaOgy5iWJthNGuXTucnJxYtGiRaQvanJwcunbtSnZ2Nt9//32JBypSWvIW0g5t3Iqqvr6WDqdEZf11iq2rv2Fo54fx9br5IuGW4u5kT2UPZ0uHISXk4B9niPlwDfPnzyc4ONjS4YiUCk9PT/z8/CwdhtW54xthTJ06lSZNmlCzZk0aN24MwMaNG8nKyuKnn34qTpUid53Q4Bplbie4Y2lpbF39DV2bR2inNSkVXinHgTUEBwdrVywRuWsU6yW4kJAQ9uzZQ5cuXThx4gTnzp2jd+/e7Nu3j9DQ0JKOUURERESkxBR7K+SqVasyadKkkoxFREREROSOK9YIMFyb8vDss88SGRnJ8ePHAZg3bx6//PJLiQUnIiIiIlLSipUAL126lNatW+Po6EhiYiKXLl0C4Ny5cxoVFhEREZG7WrES4LfeeouPP/6Y2bNnY2trazofGRlJYmJiiQUnIiIiIlLSipUA79+/nyZNmuQ77+bmxtmzZ283JhERERGRO6ZYCbCPjw8HDx7Md/6XX34hMDDwtoMSiIqKYtCgQSVSV3R0NB07diyRukRERETudcVKgPv378+rr77Ktm3bMBgM/PHHHyxYsIAhQ4bw8ssvl3SMIiIiIiIlpljLoA0dOpTMzEwee+wx/v77b5o0aYK9vT1DhgwhJiampGMUC7h8+TJ2dnaWDkNERESkxBV7GbSJEydy6tQptm/fztatWzl58iQTJkwoydjk/8yfP5+IiAhcXV3x9vamR48enDhxwqzM77//Ttu2bXFzc8PV1ZXGjRtz6NAhszLvvPMOPj4+VKpUiQEDBnDlyhXTtYCAAN566y2io6Nxd3enb9++NGvWLN8PNKdPn8be3t6041/efb1798bFxQV/f3+++eYbTp48SYcOHXBxcSEsLIydO3ea1bN06VIefPBB7O3tCQgIYNq0aWbXP/zwQ2rUqIGDgwNVqlThmWeeMYv1vffeMytft25dxo4da/o8duxY/Pz8sLe3p2rVqrzyyiuF62wREREp84qdAAM4OTlRpUoVqlatiouLS0nFJNe5fPkyEyZMYPfu3cTFxZGamkp0dLTp+vHjx2nSpAkODg789NNPJCQk0KdPH65evWoqs379eg4dOsT69euZO3cusbGxxMbGmrXz9ttvExoaSkJCAqNGjeLFF19k4cKFpmXuABYsWEDVqlV57LHHTOemT59Oo0aN2LVrF23btqVXr1707t2bZ599lsTERKpXr07v3r0xGo0AJCQk0KVLF7p168avv/7K2LFjGTVqlCmenTt38sorrzB+/Hj279/P6tWrb/jSZUG+/vprpk+fzieffMKBAweIi4sjLCyswPKXLl0iKyvL7BAREZGyq1hTIK5evcq4ceOYMWMG58+fB8DFxYWBAwcyZswYs6XR5Pb16dPH9HVgYCAzZsygQYMGnD9/HhcXF2bNmoW7uzuLFy829X1QUJBZHRUqVOCDDz6gXLly1KpVi7Zt27Ju3Tr69u1rKtOsWTOGDBli+uzr68vAgQP55ptv6NKlCwBz5swhOjoag8FgKtemTRv69+8PwOjRo/noo4946KGH6Ny5MwDDhg2jYcOG/O9//8Pb25t3332X5s2bM2rUKFOse/fu5e233yY6Opr09HScnZ1p164drq6u+Pv7U69evUL3V3p6Ot7e3rRo0QJbW1v8/Pxo0KBBgeUnT57MuHHjCl2/iIiI3NuKNQIcExPDp59+ytSpU9m1axe7du1i6tSpfPbZZwwcOLCkY7R6u3btokOHDvj7++Pq6kpUVBRwLdEDSEpKonHjxjf9wePBBx+kXLlyps8+Pj75plFERESYfba3t+fZZ5/l888/N7Wze/dus9FngNq1a5u+rlKlCoDZiGveubz2kpOTadSokVkdjRo14sCBA+Tk5NCyZUv8/f0JDAykV69eLFiwgAsXLhT4bNfr3LkzFy9eJDAwkL59+7J8+XKz0fDrDR8+nMzMTNNx9OjRQrclIiIi955iJcCLFi0iNjaW/v37U7t2bWrXrk3//v35/PPPWbRoUUnHaNWys7Np1aoVLi4uzJ8/nx07drB8+XLg2tQIAEdHx1vWc31ybDAYyM3NNTvn7Oyc774XX3yRtWvXcuzYMT7//HOaN2+Ov79/gXXnjQzf6Fxee0aj0WwEOe9cHldXVxITE1m0aBE+Pj6MHj2aOnXqmNaYtrGxMSsPmM1n9vX1Zf/+/cyaNQtHR0defvllmjRpYlbmn+zt7XFzczM7REREpOwqVgLs4OBAQEBAvvMBAQFaOaCE7du3j1OnTjFlyhQaN25MrVq18o3c1q5dm40bNxaY4N2OsLAwIiIimD17NgsXLjSbjlFcISEh/PLLL2bnNm/eTFBQkGmUunz58rRo0YKpU6eyZ88ejhw5YnrxzsvLi4yMDNO9WVlZpKammtXn6OjIk08+yYwZM4iPj2fLli38+uuvtx27iIiI3PuKlQAPGDCACRMmmL0cdenSJSZOnKhl0EqYn58fdnZ2zJw5k8OHD7NixYp8q23ExMSQlZVFt27d2LlzJwcOHGDevHns37+/RGJ48cUXmTJlCjk5OTz11FO3Xd/rr7/OunXrmDBhAikpKcydO5cPPvjANP945cqVzJgxg6SkJNLS0vjiiy/Izc2lZs2awLW5yvPmzWPjxo389ttvPPfcc2bTO2JjY/nss8/47bffOHz4MPPmzcPR0THfyLWIiIhYp2IlwLt27WLlypXcf//9tGjRghYtWnD//ffz7bffsnv3bjp16mQ65PZ4eXkRGxvLV199RUhICFOmTOGdd94xK1OpUiV++uknzp8/T9OmTalfvz6zZ88usZcRu3fvTvny5enRowcODg63XV94eDhffvklixcvJjQ0lNGjRzN+/HjT3GIPDw+WLVtGs2bNCA4O5uOPP2bRokU8+OCDwLU5u02aNKFdu3a0adOGjh07Uq1aNVP9Hh4ezJ49m0aNGlG7dm3WrVvHt99+S6VKlW47dhEREbn3GYzXT6YshOeff77QZefMmVPU6uUuc/ToUQICAtixYwfh4eGWDueOy8rKwt3dnW79BtAgomw977G0NN6dOJ6EjwcQHnSfpcMRK5CYcpz6L80iISHBKv79EBHLyfv+nZmZecv3eYq1DNqHH35Ibm6u6aWpI0eOEBcXR3BwMK1bty5OlXIXunLlChkZGbz55ps88sgj+uYlIiIiZUKxpkB06NCBefPmAXD27FkeeeQRpk2bRseOHfnoo49KNECxnE2bNuHv709CQgIff/yxpcMRERERKRHFSoATExNp3LgxcG3XrSpVqpheVpoxY0aJBiiWExUVhdFoZP/+/TfdSU1ERETkXlKsBPjChQu4uroCsGbNGjp16oSNjQ2PPPIIaWlpJRqgiIiIiEhJKlYCXL16deLi4jh69Cg//PADrVq1Aq7t9KVNBERERETkblasBHj06NEMGTKEgIAAHn74YRo2bAhcGw2uV69eiQYoIiIiIlKSirUKxDPPPMOjjz5KRkYGderUMZ1v3rx5iWyUIHI3SExI4njGiVsXLCF29g44ubje0TYyT58EYNX2FJLTT97RtkqKh4sDPhXvbL/InXOv/H8mItalWOsAi5RleesIyt3BAOgfqXubk5Mjycn78PPzs3QoIlKG3fF1gEWsQWjjVlT19S2VtrL+OsXW1d8wtPPD+Hrd2Xn07k72VPZwvqNtlJSDf5wh5sM1zJ8/n+DgYEuHI8Xk6emp5FdE7ipKgEUKEBpco9R2gjuWlsbW1d/QtXmEdmj7B6+U48AagoODtRGLiIiUmGK9BCciIiIicq9SAiwiIiIiVkUJsIiIiIhYFSXAIiIiImJVlACLiIiIiFVRAiwiIiIiVkUJsNxQVFQUgwYNsnQYABw5cgSDwUBSUpKlQxEREZEyQOsAy13P19eXjIwMPD09LR2KiIiIlAFKgOWudvnyZezs7PD29rZ0KCIiIlJGaApEGRAVFcXAgQMZNGgQFSpUoEqVKnz66adkZ2fz/PPP4+rqSrVq1fj+++9N9+zdu5c2bdrg4uJClSpV6NWrF6dOnSqwjfnz5xMREYGrqyve3t706NGDEydOmK7Hx8djMBhYt24dERERODk5ERkZyf79+01lDh06RIcOHahSpQouLi489NBD/Pjjj2btBAQE8NZbbxEdHY27uzt9+/bNNwUiNjYWDw8Ps/vi4uIwGAymz7t37+axxx7D1dUVNzc36tevz86dO4vTvSIiIlLGKAEuI+bOnYunpyfbt29n4MCB/Otf/6Jz585ERkaSmJhI69at6dWrFxcuXCAjI4OmTZtSt25ddu7cyerVq/nf//5Hly5dCqz/8uXLTJgwgd27dxMXF0dqairR0dH5yo0YMYJp06axc+dOypcvT58+fUzXzp8/T5s2bfjxxx/ZtWsXrVu3pn379qSnp5vV8fbbbxMaGkpCQgKjRo0qVn/07NmT+++/nx07dpCQkMCbb76Jra3tDcteunSJrKwss0NERETKLk2BKCPq1KnDyJEjARg+fDhTpkzB09OTvn37AjB69Gg++ugj9uzZw6pVqwgPD2fSpEmm+z///HN8fX1JSUkhKCgoX/3/TGQDAwOZMWMGDRo04Pz587i4uJiuTZw4kaZNmwLw5ptv0rZtW/7++28cHByoU6cOderUMZV96623WL58OStWrCAmJsZ0vlmzZgwZMsT0+ciRI0Xuj/T0dN544w1q1aoFQI0aNQosO3nyZMaNG1fkNkREROTepBHgMqJ27dqmr8uVK0elSpUICwsznatSpQoAJ06cICEhgfXr1+Pi4mI68hLFQ4cO3bD+Xbt20aFDB/z9/XF1dSUqKgog3+jtP+Pw8fExtQmQnZ3N0KFDCQkJwcPDAxcXF/bt25evjoiIiOJ0gZnBgwfz4osv0qJFC6ZMmVLgc8G1HxgyMzNNx9GjR2+7fREREbl7KQEuI67/9b7BYDA7lzc/Njc3l9zcXNq3b09SUpLZceDAAZo0aZKv7uzsbFq1aoWLiwvz589nx44dLF++HLg2NaKgOP7ZJsAbb7zB0qVLmThxIhs3biQpKYmwsLB8dTg7O9/0WW1sbDAajWbnrly5YvZ57Nix/P7777Rt25affvqJkJAQU8zXs7e3x83NzewQERGRsktTIKxQeHg4S5cuJSAggPLlb/2/wL59+zh16hRTpkzB19cXoFgvlG3cuJHo6Gieeuop4Nqc4OJMb/Dy8uLcuXNkZ2ebkuUbrREcFBREUFAQr732Gt27d2fOnDmmtkVERMR6aQTYCg0YMIC//vqL7t27s337dg4fPsyaNWvo06cPOTk5+cr7+flhZ2fHzJkzOXz4MCtWrGDChAlFbrd69eosW7aMpKQkdu/eTY8ePUyjw0Xx8MMP4+TkxL///W8OHjzIwoULiY2NNV2/ePEiMTExxMfHk5aWxqZNm9ixYwfBwcFFbktERETKHiXAVqhq1aps2rSJnJwcWrduTWhoKK+++iru7u7Y2OT/X8LLy4vY2Fi++uorQkJCmDJlCu+8806R250+fToVKlQgMjKS9u3b07p1a8LDw4tcT8WKFZk/fz6rVq0iLCyMRYsWMXbsWNP1cuXKcfr0aXr37k1QUBBdunThiSee0ItuIiIiAoDBeP1kShErl5WVhbu7O936DaBBRNET9OI4lpbGuxPHk/DxAMKD7iuVNu8FiSnHqf/SLBISEor1w5KIiFiPvO/fmZmZt3yfRyPAIiIiImJVlACLiIiIiFVRAiwiIiIiVkUJsIiIiIhYFSXAIiIiImJVlACLiIiIiFXRTnAiBUhMSOJ4xolSaev82TMA/HfVTqpuT8l33dXRDk/3m28RXRal/nmtX5KTky3SvqenJ35+fhZpW0RE7hytAyxynbx1BEWcnBxJTt6nJFhE5B5QlHWANQIsUoDQxq2o6utbau3Zly+Ho13+v5J/nTrJj3FfMfPlltSoWrHU4rlbODg44OriUurtJqef5NlJX3Lq1CklwCIiZYwSYJEChAbXKLWd4G7mWFoaP8ZBZO0g7RInIiJSAvQSnIiIiIhYFSXAIiIiImJVlACLiIiIiFVRAiwiIiIiVkUJsIiIiIhYFSXAIiIiImJVymQCHBUVxaBBgywdBgBHjhzBYDCQlJRk6VCKzGAwEBcXZ+kwAIiNjcXDw8PSYYiIiEgZUCYT4LuJr68vGRkZhIaGWjqUe1rXrl1JScm/RbCIiIhIUWkjjDvo8uXL2NnZ4e3tbelQ7mlXrlzB0dERR0dHS4ciIiIiZYBFR4CjoqIYOHAggwYNokKFClSpUoVPP/2U7Oxsnn/+eVxdXalWrRrff/+92X179+6lTZs2uLi4UKVKFXr16sWpU6cKbGf+/PlERETg6uqKt7c3PXr04MSJE6br8fHxGAwG1q1bR0REBE5OTkRGRrJ//35TmUOHDtGhQweqVKmCi4sLDz30ED/++KNZOwEBAbz11ltER0fj7u5O3759802BuNGv8uPi4jAYDKbPu3fv5rHHHsPV1RU3Nzfq16/Pzp07C3w+g8HAJ598Qrt27XByciI4OJgtW7Zw8OBBoqKicHZ2pmHDhhw6dMjsvm+//Zb69evj4OBAYGAg48aN4+rVqwW2M2zYMIKCgnByciIwMJBRo0Zx5coV0/WxY8dSt25d5s2bR0BAAO7u7nTr1o1z586ZyqxevZpHH30UDw8PKlWqRLt27cziyuuvL7/8kqioKBwcHJg/f36+fouOjqZjx45m8Q0aNIioqCjT56+//pqwsDAcHR2pVKkSLVq0IDs7u8DnExEREetg8SkQc+fOxdPTk+3btzNw4ED+9a9/0blzZyIjI0lMTKR169b06tWLCxcuAJCRkUHTpk2pW7cuO3fuZPXq1fzvf/+jS5cuBbZx+fJlJkyYwO7du4mLiyM1NZXo6Oh85UaMGMG0adPYuXMn5cuXp0+fPqZr58+fp02bNvz444/s2rWL1q1b0759e9LT083qePvttwkNDSUhIYFRo0YVq0969uzJ/fffz44dO0hISODNN9/E1tb2pvdMmDCB3r17k5SURK1atejRowf9+/dn+PDhpuQ5JibGVP6HH37g2Wef5ZVXXmHv3r188sknxMbGMnHixALbcHV1JTY2lr179/L+++8ze/Zspk+fblbm0KFDxMXFsXLlSlauXMmGDRuYMmWK6Xp2djaDBw9mx44drFu3DhsbG5566ilyc3PN6hk2bBivvPIKycnJtG7dutB9lycjI4Pu3bvTp08fkpOTiY+Pp1OnThiNxnxlL126RFZWltkhIiIiZZfFp0DUqVOHkSNHAjB8+HCmTJmCp6cnffv2BWD06NF89NFH7Nmzh0ceeYSPPvqI8PBwJk2aZKrj888/x9fXl5SUFIKCgvK18c9ENjAwkBkzZtCgQQPOnz+Pi4uL6drEiRNp2rQpAG+++SZt27bl77//xsHBgTp16lCnTh1T2bfeeovly5ezYsUKs8SyWbNmDBkyxPT5yJEjRe6T9PR03njjDWrVqgVAjRo1bnnP888/b/ohYNiwYTRs2JBRo0aZksdXX32V559/3uxZ33zzTZ577jngWr9MmDCBoUOHMmbMmBu2kffnBNdGu19//XWWLFnC0KFDTedzc3OJjY3F1dUVgF69erFu3TpTYv3000+b1fnZZ59RuXJl9u7dazZPetCgQXTq1OmWz12QjIwMrl69SqdOnfD39wcgLCzshmUnT57MuHHjit2WiIiI3FssPgJcu3Zt09flypWjUqVKZolKlSpVAExTFhISEli/fj0uLi6mIy9RvP5X/Hl27dpFhw4d8Pf3x9XV1fRr8utHb/8Zi4+Pj1m72dnZDB06lJCQEDw8PHBxcWHfvn356oiIiChyH1xv8ODBvPjii7Ro0YIpU6YU+FwFxZ7XZ9f3499//20a3UxISGD8+PFm/di3b18yMjJMo+3X+/rrr3n00Ufx9vbGxcWFUaNG5Xv+gIAAU/IL1/rxn9NNDh06RI8ePQgMDMTNzY0HHngAyP9ncbv9WKdOHZo3b05YWBidO3dm9uzZnDlz5oZlhw8fTmZmpuk4evTobbUtIiIidzeLJ8DX/2rfYDCYncubG5v3K/Lc3Fzat29PUlKS2XHgwAGaNGmSr/7s7GxatWqFi4sL8+fPZ8eOHSxfvhy4NjWioFiub/eNN95g6dKlTJw4kY0bN5KUlERYWFi+OpydnW/6vDY2Nvl+Df/PebRwbS7t77//Ttu2bfnpp58ICQkxxVyQG8V+q34cN26cWR/++uuvHDhwAAcHh3z1b926lW7duvHEE0+wcuVKdu3axYgRI27ah3nt/nN6Q/v27Tl9+jSzZ89m27ZtbNu2Dcj/Z3G7/ViuXDnWrl3L999/T0hICDNnzqRmzZqkpqbmq8ve3h43NzezQ0RERMoui0+BKKrw8HCWLl1KQEAA5cvfOvx9+/Zx6tQppkyZgq+vL8BNXygryMaNG4mOjuapp54Crs0JLs70Bi8vL86dO0d2drYpybvRGsFBQUEEBQXx2muv0b17d+bMmWNquySEh4ezf/9+qlevXqjymzZtwt/fnxEjRpjOpaWlFanN06dPk5yczCeffELjxo0B+OWXX4pURx4vLy9+++03s3NJSUn5kv5GjRrRqFEjRo8ejb+/P8uXL2fw4MHFalNERETKBouPABfVgAED+Ouvv+jevTvbt2/n8OHDrFmzhj59+pCTk5OvvJ+fH3Z2dsycOZPDhw+zYsUKJkyYUOR2q1evzrJly0hKSmL37t306NEj34tbhfHwww/j5OTEv//9bw4ePMjChQuJjY01Xb948SIxMTHEx8eTlpbGpk2b2LFjB8HBwUVu62ZGjx7NF198YRptTk5OZsmSJWbzfP+pevXqpKens3jxYg4dOsSMGTNuOSp9vQoVKlCpUiU+/fRTDh48yE8//VTsZLRZs2bs3LmTL774ggMHDjBmzBizhHjbtm1MmjSJnTt3kp6ezrJlyzh58mSJ96OIiIjce+65BLhq1aps2rSJnJwcWrduTWhoKK+++iru7u7Y2OR/HC8vL2JjY/nqq68ICQlhypQpvPPOO0Vud/r06VSoUIHIyEjat29P69atCQ8PL3I9FStWZP78+axatYqwsDAWLVrE2LFjTdfLlSvH6dOn6d27N0FBQXTp0oUnnniixF/Sat26NStXrmTt2rU89NBDPPLII7z77rumF8au16FDB1577TViYmKoW7cumzdvLvIqFzY2NixevJiEhARCQ0N57bXXePvtt4sd/6hRoxg6dCgPPfQQ586do3fv3qbrbm5u/Pzzz7Rp04agoCBGjhzJtGnTeOKJJ4rVnoiIiJQdBuON1oUSsWJZWVnX1jDuN4AGEUX/IaekHUtL492J40n4eADhQfdZOhyrkZhynPovzSIhIaFYP+yKiEjpyvv+nZmZecv3ee65EWARERERkduhBFhERERErIoSYBERERGxKkqARURERMSqKAEWEREREauiBFhERERErMo9txOcSGlJTEjieMYJS4fB+bNnAFj4026S009aOBrrkfrntX5PTk4u9bY9PT3x8/Mr9XZFRKyF1gEWuU7eOoIiluLk5Ehy8j4lwSIiRVCUdYA1AixSgNDGrajq62vpMAC4mHmGjd8tY+bLLalRtaKlw7EaDg4OuLq4lGqbyekneXbSl5w6dUoJsIjIHaIEWKQAocE17oqd4ODabnAbv1tGZO0g7QYnIiJym/QSnIiIiIhYFSXAIiIiImJVlACLiIiIiFVRAiwiIiIiVkUJsIiIiIhYFSXAIiIiImJVlACLmfj4eAwGA2fPni3VdqOiohg0aFCptikiIiLWSesAy11h2bJl2NraWjoMERERsQJKgOWuULGidjcTERGR0qEpEKUsKiqKmJgYYmJi8PDwoFKlSowcORKj0QjA5cuXGTp0KPfddx/Ozs48/PDDxMfHm+6PjY3Fw8ODH374geDgYFxcXHj88cfJyMgwlYmPj6dBgwY4Ozvj4eFBo0aNSEtL48iRI9jY2LBz506zmGbOnIm/v78phjyZmZk4OjqyevVqs/PLli3D2dmZ8+fPAzBs2DCCgoJwcnIiMDCQUaNGceXKFVP5sWPHUrduXebNm0dAQADu7u5069aNc+fOmfXLP6dAXLp0iaFDh+Lr64u9vT01atTgs88+M+uDf4qLi8NgMJg+7969m8ceewxXV1fc3NyoX79+vucWERER66QE2ALmzp1L+fLl2bZtGzNmzGD69On897//BeD5559n06ZNLF68mD179tC5c2cef/xxDhw4YLr/woULvPPOO8ybN4+ff/6Z9PR0hgwZAsDVq1fp2LEjTZs2Zc+ePWzZsoV+/fphMBgICAigRYsWzJkzxyyeOXPmEB0dbZZAAri7u9O2bVsWLFhgdn7hwoV06NABFxcXAFxdXYmNjWXv3r28//77zJ49m+nTp5vdc+jQIeLi4li5ciUrV65kw4YNTJkypcA+6t27N4sXL2bGjBkkJyfz8ccfm9orjJ49e3L//fezY8cOEhISePPNNwucYnHp0iWysrLMDhERESm7NAXCAnx9fZk+fToGg4GaNWvy66+/Mn36dJo1a8aiRYs4duwYVatWBWDIkCGsXr2aOXPmMGnSJACuXLnCxx9/TLVq1QCIiYlh/PjxAGRlZZGZmUm7du1M14ODg01tv/jii7z00ku8++672Nvbs3v3bpKSkli2bNkNY+3Zsye9e/fmwoULODk5kZWVxXfffcfSpUtNZUaOHGn6OiAggNdff50lS5YwdOhQ0/nc3FxiY2NxdXUFoFevXqxbt46JEyfmazMlJYUvv/yStWvX0qJFCwACAwOL1Mfp6em88cYb1KpVC4AaNWoUWHby5MmMGzeuSPWLiIjIvUsjwBbwyCOPmI22NmzYkAMHDrBz506MRiNBQUG4uLiYjg0bNnDo0CFTeScnJ1NyC+Dj48OJEyeAa3Npo6Ojad26Ne3bt+f99983mx7RsWNHypcvz/LlywH4/PPPeeyxxwgICLhhrG3btqV8+fKsWLECgKVLl+Lq6kqrVq1MZb7++mseffRRvL29cXFxYdSoUaSnp5vVExAQYEp+r4/5eklJSZQrV46mTZvetB9vZvDgwbz44ou0aNGCKVOmmPXf9YYPH05mZqbpOHr0aLHbFRERkbufEuC7TLly5UhISCApKcl0JCcn8/7775vKXP+rfIPBYDZ/d86cOWzZsoXIyEiWLFlCUFAQW7duBcDOzo5evXoxZ84cLl++zMKFC+nTp0+B8djZ2fHMM8+wcOFC4Nr0h65du1K+/LVfHmzdupVu3brxxBNPsHLlSnbt2sWIESO4fPmyWT03ijk3N/eGbTo6Ot60j2xsbPLNV/7nnGO4Nu/4999/p23btvz000+EhISYkv7r2dvb4+bmZnaIiIhI2aUE2ALyktF/fq5Rowb16tUjJyeHEydOUL16dbPD29u7SG3Uq1eP4cOHs3nzZkJDQ00JLFybBvHjjz/y4YcfcuXKFTp16nTTunr27Mnq1av5/fffWb9+PT179jRd27RpE/7+/owYMYKIiAhq1KhBWlpakWK9XlhYGLm5uWzYsOGG1728vDh37hzZ2dmmc0lJSfnKBQUF8dprr7FmzRo6deqUb+6ziIiIWCclwBZw9OhRBg8ezP79+1m0aBEzZ87k1VdfJSgoyDTndtmyZaSmprJjxw7+85//sGrVqkLVnZqayvDhw9myZQtpaWmsWbOGlJQUs3nAwcHBPPLIIwwbNozu3bvfcsS1adOmVKlShZ49exIQEMAjjzxiula9enXS09NZvHgxhw4dYsaMGQWOtBZWQEAAzz33HH369CEuLo7U1FTi4+P58ssvAXj44YdxcnLi3//+NwcPHmThwoXExsaa7r948SIxMTHEx8eTlpbGpk2b2LFjh1kfiIiIiPVSAmwBvXv35uLFizRo0IABAwYwcOBA+vXrB1ybvtC7d29ef/11atasyZNPPsm2bdvw9fUtVN1OTk7s27ePp59+mqCgIPr160dMTAz9+/c3K/fCCy9w+fLlm05/yGMwGOjevTu7d+82G/0F6NChA6+99hoxMTHUrVuXzZs3M2rUqEL2RME++ugjnnnmGV5++WVq1apF3759TSO+FStWZP78+axatYqwsDAWLVrE2LFjTfeWK1eO06dP07t3b4KCgujSpQtPPPGEXnQTERERAAzG6ydTyh0VFRVF3bp1ee+99ywax8SJE1m8eDG//vqrReO4G2VlZV1bq7jfABpEhFs6HACOpaXx7sTxJHw8gPCg+ywdjtxBiSnHqf/SLBISEggPvzv+/xMRuRfkff/OzMy85fs8GgG2MufPn2fHjh3MnDmTV155xdLhiIiIiJQ6JcBWJiYmhkcffZSmTZsWavqDiIiISFmjjTBK2T+3NbaE2NhYsxfGRERERKyNRoBFRERExKooARYRERERq6IpECIiIiKlKCcnJ98OplI4dnZ22Njc/vitEmCRAiQmJHE844RF2razd8DJxdX0OfP0SQBWbU8hOf2kRWIqKzxcHPCp6HrrghaiP1+RsstoNPLnn39y9uxZS4dyz7KxseGBBx7Azs7uturROsAi18lbR1DKJgNwt/+j5+TkSHLyPvz8/CwdioiUoIyMDM6ePUvlypVxcnLCYDBYOqR7Sm5uLn/88Qe2trb4+fnl67+irAOsEWCRAoQ2bkXVQu7AV5Ky/jrF1tXfMLTzw/h6/f+/wO5O9lT2cC71eMqSg3+cIebDNcyfP/+u3hrb09NTya9IGZOTk2NKfitVqmTpcO5ZXl5e/PHHH1y9ehVbW9ti16MEWKQAocE1LLIT3LG0NLau/oauzSO061sJ80o5DqwhODhYu6yJSKnKm/Pr5ORk4UjubXlTH3Jycm4rAdYqECIiIiKlRNMebk9J9Z8SYBERERGxKkqARURERMRMVFQUgwYNMn0OCAjgvffes1g8JU1zgEVERETkpnbs2IGz8/9/EdtgMLB8+XI6duxouaBugxJgEREREbkpLy8vS4dQojQFQkRERKQM+vrrrwkLC8PR0ZFKlSrRokULsrOziY6OpmPHjowbN47KlSvj5uZG//79uXz5coF1/XMKREBAAABPPfUUBoPB9PleogRYSlVsbCweHh6WDkNERKRMy8jIoHv37vTp04fk5GTi4+Pp1KkTefufrVu3juTkZNavX8+iRYtYvnw548aNK1TdO3bsAGDOnDlkZGSYPt9LlADLbcv7SbIwunbtSkpKSqHrLmuT7kVEREpDRkYGV69epVOnTgQEBBAWFsbLL7+Mi4sLcG093c8//5wHH3yQtm3bMn78eGbMmEFubu4t686bDuHh4YG3t/c9OT1CCbDc9FceJenKlSs4OjpSuXLlUmlPRETEWtWpU4fmzZsTFhZG586dmT17NmfOnDG7/s9NORo2bMj58+c5evSoJcItdUqArVBUVBQxMTEMHjwYT09PWrZsyd69e2nTpg0uLi5UqVKFXr16cerUKdM9Bc0jGjt2LHPnzuWbb77BYDBgMBiIj4/nyJEjGAwGvvzyS6KionBwcGD+/Pk3nAKxYsUKIiIicHBwwNPTk06dOpniTEtL47XXXjPVDTB27Fjq1q1rVsd7771nNgcpPj6eBg0a4OzsjIeHB40aNSItLe2O9KeIiMjdply5cqxdu5bvv/+ekJAQZs6cSc2aNUlNTb3pfdayUYcSYCs1d+5cypcvz6ZNm5gyZQpNmzalbt267Ny5k9WrV/O///2PLl26ADefRzRkyBC6dOnC448/TkZGBhkZGURGRpraGTZsGK+88grJycm0bt06XxzfffcdnTp1om3btuzatYt169YREREBwLJly7j//vsZP368qe7CuHr1Kh07dqRp06bs2bOHLVu20K9fvwL/Ul+6dImsrCyzQ0RE5F5nMBho1KgR48aNY9euXdjZ2bF8+XIAdu/ezcWLF01lt27diouLC/fff3+h6ra1tSUnJ+eOxF0atAyalapevTpTp04FYPTo0YSHhzNp0iTT9c8//xxfX19SUlI4f/68aR6Rv78/AGFhYaayjo6OXLp0CW9v73ztDBo0yDSieyMTJ06kW7duZhPv69SpA0DFihUpV64crq6uN6y7IFlZWWRmZtKuXTuqVasGQHBwcIHlJ0+eXOiJ/yIiIveCbdu2sW7dOlq1akXlypXZtm0bJ0+eJDg4mD179nD58mVeeOEFRo4cSVpaGmPGjCEmJgYbm8KNjQYEBLBu3ToaNWqEvb09FSpUuMNPVLI0Amyl8kZZARISEli/fj0uLi6mo1atWgAcOnTolvOICtvOjSQlJdG8efPiP8gNVKxYkejoaFq3bk379u15//33bzp6PHz4cDIzM02Htcx/EhGRssvNzY2ff/6ZNm3aEBQUxMiRI5k2bRpPPPEEAM2bN6dGjRo0adKELl260L59e8aOHVvo+qdNm8batWvx9fWlXr16d+gp7hyNAFupf+7mkpubS/v27fnPf/6Tr5yPj49pHtHmzZtZs2YNM2fOZMSIEWzbto0HHnig0O3ciKOjY5Fjt7GxMS3jkufKlStmn+fMmcMrr7zC6tWrWbJkCSNHjmTt2rU88sgj+eqzt7fH3t6+yHGIiIjcrYKDg1m9evVNy4wbN67A34DGx8ebfT5y5IjZ5/bt29O+ffvbCdGiNAIshIeH8/vvvxMQEED16tXNjrwE9mbziOzs7Io9D6h27dqsW7euwOs3qtvLy4s///zTLAlOSkrKd2+9evUYPnw4mzdvJjQ0lIULFxYrRhERESlblAALAwYM4K+//qJ79+5s376dw4cPs2bNGvr06UNOTg7btm1j0qRJ7Ny5k/T0dJYtW2aaRwTX5gHt2bOH/fv3c+rUqXyjsTczZswYFi1axJgxY0hOTubXX381zU3Oq/vnn3/m+PHjplUpoqKiOHnyJFOnTuXQoUPMmjWL77//3nRPamoqw4cPZ8uWLaSlpbFmzRpSUlJuOg9YRERErIcSYKFq1aps2rSJnJwcWrduTWhoKK+++iru7u7Y2Njcch5R3759qVmzJhEREXh5ebFp06ZCtx0VFcVXX33FihUrqFu3Ls2aNWPbtm2m6+PHj+fIkSNUq1bNtNB2cHAwH374IbNmzaJOnTps376dIUOGmO5xcnJi3759PP300wQFBdGvXz9iYmLo379/CfWYiIjIvSs2Npa4uDhLh2FRBuP1kylFrFxWVhbu7u506zeABhHhpd7+sbQ03p04noSPBxAedF+pt1+WJaYcp/5Ls0hISCA8vPT/bEXEev3999+kpqbywAMP4ODgYOlw7lk368e879+ZmZm4ubndtB6NAIuIiIiIVVECLCIiIiJWRQmwiIiIiFgVJcAiIiIiYlWUAIuIiIiIVdFOcCIiIiIWlJ6eblrr/k7z9PTEz8+vVNq6mykBFilAYkISxzNOlHq758+eAeC/q3ZSdXtKke51dbTD0/3m209bs9Q/r/VtcnKyhSO5PfoGJlJ2pKenUys4mIsXLpRKe45OTuxLTi7SvyFRUVHUrVuX9957r0RiiI6O5uzZsxZdi1gJsEgBUhI2kZJgufY/WrHt1oWkWJ599llLh3BbnJwcSU7epyRYpAw4deoUFy9coOewt6niV+2OtvW/9EMs+M8bnDp1yur//VACLFKA0MatqOrra5G27cuXw9GuaH89/zp1kh/jvmLmyy2pUbXiHYrs3ufg4ICri4ulwyi25PSTPDvpS30DEyljqvhV4/4aD1o6jHyio6PZsGEDGzZs4P333wcgNTWVCxcuMGTIEH7++WecnZ1p1aoV06dPx9PTE4Cvv/6acePGcfDgQZycnKhXrx7ffPMNb7/9NnPnzgXAYDAAsH79eqKiokr1uZQAixQgNLiGRXaCK65jaWn8GAeRtYO0g5yIiJSI999/n5SUFEJDQxk/fjwAOTk5NG3alL59+/Luu+9y8eJFhg0bRpcuXfjpp5/IyMige/fuTJ06laeeeopz586xceNGjEYjQ4YMITk5maysLObMmQNAxYqlP2ijBFhEREREbsjd3R07OzucnJzw9vYGYPTo0YSHhzNp0iRTuc8//xxfX19SUlI4f/48V69epVOnTvj7+wMQFhZmKuvo6MilS5dM9VmCEmARERERKbSEhATWr1+Pyw2mkx06dIhWrVrRvHlzwsLCaN26Na1ateKZZ56hQoUKFoj2xrQOsIiIiIgUWm5uLu3btycpKcnsOHDgAE2aNKFcuXKsXbuW77//npCQEGbOnEnNmjVJTU21dOgmSoBFREREpEB2dnbk5OSYPoeHh/P7778TEBBA9erVzQ5n52tLcRoMBho1asS4cePYtWsXdnZ2LF++/Ib1WYKmQIiIiIhY2P/SD921bQQEBLBt2zaOHDmCi4sLAwYMYPbs2XTv3p033ngDT09PDh48yOLFi5k9ezY7d+5k3bp1tGrVisqVK7Nt2zZOnjxJcHCwqb4ffviB/fv3U6lSJdzd3bG1tS3JR70lJcAiIiIiFuLp6YmjkxML/vNGqbTn6ORkWqqssIYMGcJzzz1HSEgIFy9eJDU1lU2bNjFs2DBat27NpUuX8Pf35/HHH8fGxgY3Nzd+/vln3nvvPbKysvD392fatGk88cQTAPTt25f4+HgiIiI4f/68lkETERERsSZ+fn7sS06+q7dCDgoKYsuWLfnOL1u27Iblg4ODWb16dYH1eXl5sWbNmiLFUNKUAEuJKOltEkVERKyFn5+fNrYpZXoJTu4aly9ftnQIIiIiYgWUAMtty9sm8f3338dgMGAwGDhy5AgbNmygQYMG2Nvb4+Pjw5tvvsnVq1dN90VFRRETE8PgwYPx9PSkZcuWdO/enW7dupnVf+XKFTw9PU07xgQEBOQbaa5bty5jx441fR47dix+fn7Y29tTtWpVXnnllTv2/CIiInJv0RQIuW0FbZPYpk0boqOj+eKLL9i3bx99+/bFwcHBLFGdO3cu//rXv9i0aRNGo5GDBw/SpUsXzp8/b1pg+4cffiA7O5unn366UPF8/fXXTJ8+ncWLF/Pggw/y559/snv37gLLX7p0iUuXLpk+Z2VlFaMXRERE5F6hBFhu2422SRwxYgS+vr588MEHGAwGatWqxR9//MGwYcMYPXo0NjbXfvlQvXp1pk6daqqrWrVqODs7s3z5cnr16gXAwoULad++PW5uboWKJz09HW9vb1q0aIGtrS1+fn40aNCgwPKTJ09m3LhxxX18ERERucdoCoTcEcnJyTRs2BCDwWA616hRI86fP8+xY8dM5yIiIszus7W1pXPnzixYsACA7OxsvvnmG3r27Fnotjt37szFixcJDAykb9++LF++3GzqxfWGDx9OZmam6Th69Gih2xIREZF7jxJguSOMRqNZ8pt3DjA7n7djzD/17NmTH3/8kRMnThAXF4eDg4Np7UAAGxsbU115rly5Yvra19eX/fv3M2vWLBwdHXn55Zdp0qSJWZl/sre3x83NzewQERGRsksJsJSI67c1DAkJYfPmzWaJ6ubNm3F1deW+++67aV2RkZH4+vqyZMkSFixYQOfOnbGzszNd9/LyIiMjw/Q5Kysr3/7ijo6OPPnkk8yYMYP4+Hi2bNnCr7/+eruPKSIiImWA5gBLibh+m8SXX36Z9957j4EDBxITE8P+/fsZM2YMgwcPNs3/LYjBYKBHjx58/PHHpKSksH79erPrzZo1IzY2lvbt21OhQgVGjRpFuXLlTNdjY2PJycnh4YcfxsnJiXnz5uHo6Ii/v/8deXYRERG5tygBlhJxo20SV61axRtvvEGdOnWoWLEiL7zwAiNHjixUfT179mTSpEn4+/vTqFEjs2vDhw/n8OHDtGvXDnd3dyZMmGA2Auzh4cGUKVMYPHgwOTk5hIWF8e2331KpUqUSfWYREZGSkJ6eflfvBFeSAgICGDRoEIMGDbJYDKAEWErIjbZJDAgIYPv27QXeEx8fX+C1kJCQfPN887i5ubFkyRKzc88995zp644dO9KxY8dbBy0iImJh6enpBAfX4sKFi6XSnpOTI8nJ+4qUBJfkbq87duy44fs/pU0JsIiIiIiFnDp1igsXLjL/310I9vO6o20lp5/k2UlfcurUqRIdBTYajeTk5FC+/K3TSi+vO/uMhaUEWERERMTCgv28CA+6+UvilpC322vejq8Ac+bM4fnnn2f16tWMGDGCPXv28MMPP+Dn58fgwYPZunUr2dnZBAcHM3nyZFq0aGGq7/opEAaDgdmzZ/Pdd9/xww8/cN999zFt2jSefPLJO/pcWgVCRERERG7o/fffp2HDhvTt25eMjAwyMjLw9fUFYOjQoUyePJnk5GRq167N+fPnadOmDT/++CO7du2idevWtG/fnvT09Ju2MW7cOLp06cKePXto06YNPXv25K+//rqjz6UEWERERERu6PrdXr29vU0rL40fP56WLVtSrVo1KlWqRJ06dejfvz9hYWHUqFGDt956i8DAQFasWHHTNqKjo+nevTvVq1dn0qRJZGdn3/QdopKgBFhEREREiuz63Vyzs7MZOnQoISEheHh44OLiwr59+245Aly7dm3T187Ozri6unLixIk7EnMezQEWERERkSK7fjWHN954gx9++IF33nmH6tWr4+joyDPPPMPly5dvWo+tra3ZZ4PBQG5ubonH+09KgEUKkJ5+HDs7e0uHUWin/++n5eT0kxaORO4k/fmKSGm7frfXgmzcuJHo6GieeuopAM6fP8+RI0fucHTFowRYpACbV8ex2dJBFMOzk760dAhyhzk5OeLp6WnpMESkBJXGD7fFbeP63V4LGp2tXr06y5Yto3379hgMBkaNGnXHR3KLSwmwSAE+/fRTnJycLB1GkXh4eODj42PpMOQOs/ROTiJScjw9PXFyciy1wYvi/AB9/W6vc+bMuWG56dOn06dPHyIjI/H09GTYsGFkZWWVRNglzmAsaLstESuVlZWFu7s7mZmZuLm5WTocEREpA/7++29SU1N54IEHcHBwMLtmTVsh366b9WNRvn9rBFhERETEgvz8/O7ppPRepGXQRERERMSqKAEWEREREauiBFhERERErIoSYBEREZFSorUHbk9J9Z8SYBEREZE7LG+3swsXLlg4kntb3q5y5cqVu616tAqEiIiIyB1Wrlw5PDw8OPF/u3Y6OTlhMBgsHNW9JTc3l5MnT+Lk5ET58reXwioBFhERESkF3t7eAKYkWIrOxsYGPz+/2/7hQQmwiIiISCkwGAz4+PhQuXJlrly5Yulw7kl2dnbY2Nz+DF4lwCIiIiKlqFy5crc9h1Vuj16CExERERGrogRYRERERKyKEmARERERsSqaAyxynbxFtrOysiwciYiIiBRW3vftwmyWoQRY5DqnT58GwNfX18KRiIiISFGdO3cOd3f3m5ZRAixynYoVKwKQnp5+y79AUjRZWVn4+vpy9OhR3NzcLB1OmaK+vXPUt3eO+vbOsca+NRqNnDt3jqpVq96yrBJgkevkrS/o7u5uNf9olDY3Nzf17R2ivr1z1Ld3jvr2zrG2vi3swJVeghMRERERq6IEWERERESsihJgkevY29szZswY7O3tLR1KmaO+vXPUt3eO+vbOUd/eOerbmzMYC7NWhIiIiIhIGaERYBERERGxKkqARURERMSqKAEWEREREauiBFhERERErIoSYJHrfPjhhzzwwAM4ODhQv359Nm7caOmQ7mqTJ0/moYcewtXVlcqVK9OxY0f2799vVsZoNDJ27FiqVq2Ko6MjUVFR/P7772ZlLl26xMCBA/H09MTZ2Zknn3ySY8eOleaj3NUmT56MwWBg0KBBpnPq19tz/Phxnn32WSpVqoSTkxN169YlISHBdF39W3RXr15l5MiRPPDAAzg6OhIYGMj48ePJzc01lVG/Fs7PP/9M+/btqVq1KgaDgbi4OLPrJdWPZ86coVevXri7u+Pu7k6vXr04e/bsHX66u4BRREwWL15stLW1Nc6ePdu4d+9e46uvvmp0dnY2pqWlWTq0u1br1q2Nc+bMMf7222/GpKQkY9u2bY1+fn7G8+fPm8pMmTLF6Orqaly6dKnx119/NXbt2tXo4+NjzMrKMpV56aWXjPfdd59x7dq1xsTERONjjz1mrFOnjvHq1auWeKy7yvbt240BAQHG2rVrG1999VXTefVr8f31119Gf39/Y3R0tHHbtm3G1NRU448//mg8ePCgqYz6t+jeeustY6VKlYwrV640pqamGr/66iuji4uL8b333jOVUb8WzqpVq4wjRowwLl261AgYly9fbna9pPrx8ccfN4aGhho3b95s3Lx5szE0NNTYrl270npMi1ECLPIPDRo0ML700ktm52rVqmV88803LRTRvefEiRNGwLhhwwaj0Wg05ubmGr29vY1Tpkwxlfn777+N7u7uxo8//thoNBqNZ8+eNdra2hoXL15sKnP8+HGjjY2NcfXq1aX7AHeZc+fOGWvUqGFcu3atsWnTpqYEWP16e4YNG2Z89NFHC7yu/i2etm3bGvv06WN2rlOnTsZnn33WaDSqX4vr+gS4pPpx7969RsC4detWU5ktW7YYAeO+ffvu8FNZlqZAiPyfy5cvk5CQQKtWrczOt2rVis2bN1soqntPZmYmABUrVgQgNTWVP//806xf7e3tadq0qalfExISuHLlilmZqlWrEhoaavV9P2DAANq2bUuLFi3Mzqtfb8+KFSuIiIigc+fOVK5cmXr16jF79mzTdfVv8Tz66KOsW7eOlJQUAHbv3s0vv/xCmzZtAPVrSSmpftyyZQvu7u48/PDDpjKPPPII7u7uZb6vy1s6AJG7xalTp8jJyaFKlSpm56tUqcKff/5poajuLUajkcGDB/Poo48SGhoKYOq7G/VrWlqaqYydnR0VKlTIV8aa+37x4sUkJiayY8eOfNfUr7fn8OHDfPTRRwwePJh///vfbN++nVdeeQV7e3t69+6t/i2mYcOGkZmZSa1atShXrhw5OTlMnDiR7t27A/r/tqSUVD/++eefVK5cOV/9lStXLvN9rQRY5DoGg8Hss9FozHdObiwmJoY9e/bwyy+/5LtWnH615r4/evQor776KmvWrMHBwaHAcurX4snNzSUiIoJJkyYBUK9ePX7//Xc++ugjevfubSqn/i2aJUuWMH/+fBYuXMiDDz5IUlISgwYNomrVqjz33HOmcurXklES/Xij8tbQ15oCIfJ/PD09KVeuXL6fek+cOJHvp2zJb+DAgaxYsYL169dz//33m857e3sD3LRfvb29uXz5MmfOnCmwjLVJSEjgxIkT1K9fn/Lly1O+fHk2bNjAjBkzKF++vKlf1K/F4+PjQ0hIiNm54OBg0tPTAf1/W1xvvPEGb775Jt26dSMsLIxevXrx2muvMXnyZED9WlJKqh+9vb353//+l6/+kydPlvm+VgIs8n/s7OyoX78+a9euNTu/du1aIiMjLRTV3c9oNBITE8OyZcv46aefeOCBB8yuP/DAA3h7e5v16+XLl9mwYYOpX+vXr4+tra1ZmYyMDH777Ter7fvmzZvz66+/kpSUZDoiIiLo2bMnSUlJBAYGql9vQ6NGjfIt15eSkoK/vz+g/2+L68KFC9jYmKcW5cqVMy2Dpn4tGSXVjw0bNiQzM5Pt27ebymzbto3MzMyy39eWePNO5G6VtwzaZ599Zty7d69x0KBBRmdnZ+ORI0csHdpd61//+pfR3d3dGB8fb8zIyDAdFy5cMJWZMmWK0d3d3bhs2TLjr7/+auzevfsNl+u5//77jT/++KMxMTHR2KxZM6tb9uhW/rkKhNGofr0d27dvN5YvX944ceJE44EDB4wLFiwwOjk5GefPn28qo/4tuueee8543333mZZBW7ZsmdHT09M4dOhQUxn1a+GcO3fOuGvXLuOuXbuMgPHdd9817tq1y7QsZ0n14+OPP26sXbu2ccuWLcYtW7YYw8LCtAyaiDWaNWuW0d/f32hnZ2cMDw83LeclNwbc8JgzZ46pTG5urnHMmDFGb29vo729vbFJkybGX3/91ayeixcvGmNiYowVK1Y0Ojo6Gtu1a2dMT08v5ae5u12fAKtfb8+3335rDA0NNdrb2xtr1apl/PTTT82uq3+LLisry/jqq68a/fz8jA4ODsbAwEDjiBEjjJcuXTKVUb8Wzvr162/4b+tzzz1nNBpLrh9Pnz5t7Nmzp9HV1dXo6upq7Nmzp/HMmTOl9JSWYzAajUbLjD2LiIiIiJQ+zQEWEREREauiBFhERERErIoSYBERERGxKkqARURERMSqKAEWEREREauiBFhERERErIoSYBERERGxKkqARURERMSqKAEWEREREauiBFhERO4Zf/75JwMHDiQwMBB7e3t8fX1p374969atK9U4DAYDcXFxpdqmiJSc8pYOQEREpDCOHDlCo0aN8PDwYOrUqdSuXZsrV67www8/MGDAAPbt22fpEEXkHmEwGo1GSwchIiJyK23atGHPnj3s378fZ2dns2tnz57Fw8OD9PR0Bg4cyLp167CxseHxxx9n5syZVKlSBYDo6GjOnj1rNno7aNAgkpKSiI+PByAqKoratWvj4ODAf//7X+zs7HjppZcYO3YsAAEBAaSlpZnu9/f358iRI3fy0UWkhGkKhIiI3PX++usvVq9ezYABA/IlvwAeHh4YjUY6duzIX3/9xYYNG1i7di2HDh2ia9euRW5v7ty5ODs7s23bNqZOncr48eNZu3YtADt27ABgzpw5ZGRkmD6LyL1DUyBEROSud/DgQYxGI7Vq1SqwzI8//siePXtITU3F19cXgHnz5vHggw+yY8cOHnrooUK3V7t2bcaMGQNAjRo1+OCDD1i3bh0tW7bEy8sLuJZ0e3t738ZTiYilaARYRETuenmz9QwGQ4FlkpOT8fX1NSW/ACEhIXh4eJCcnFyk9mrXrm322cfHhxMnThSpDhG5eykBFhGRu16NGjUwGAw3TWSNRuMNE+R/nrexseH6V1+uXLmS7x5bW1uzzwaDgdzc3OKELiJ3ISXAIiJy16tYsSKtW7dm1qxZZGdn57t+9uxZQkJCSE9P5+jRo6bze/fuJTMzk+DgYAC8vLzIyMgwuzcpKanI8dja2pKTk1Pk+0Tk7qAEWERE7gkffvghOTk5NGjQgKVLl3LgwAGSk5OZMWMGDRs2pEWLFtSuXZuePXuSmJjI9u3b6d27N02bNiUiIgKAZs2asXPnTr744gsOHDjAmDFj+O2334ocS0BAAOvWrePPP//kzJkzJf2oInKHKQEWEZF7wgMPPEBiYiKPPfYYr7/+OqGhobRs2ZJ169bx0UcfmTanqFChAk2aNKFFixYEBgayZMkSUx2tW7dm1KhRDB06lIceeohz587Ru3fvIscybdo01q5di6+vL/Xq1SvJxxSRUqB1gEVERETEqmgEWERERESsihJgEREREbEqSoBFRERExKooARYRERERq6IEWERERESsihJgEREREbEqSoBFRERExKooARYRERERq6IEWERERESsihJgEREREbEqSoBFRERExKr8P1xGXqSDQn6dAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.histplot(df.sort_values(\"species\"), y = \"species\", hue = \"split\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save CSV\n",
+    "\n",
+    "We don't need the `filepath` column since we're including the `file_name` for the purpose of the dataset viewer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>filename</th>\n",
+       "      <th>md5</th>\n",
+       "      <th>species</th>\n",
+       "      <th>split</th>\n",
+       "      <th>file_name</th>\n",
+       "      <th>subset</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>beetle_1176_1088.png</td>\n",
+       "      <td>dcd4b79619ac96fd7519225f3bd46a86</td>\n",
+       "      <td>advena</td>\n",
+       "      <td>test</td>\n",
+       "      <td>test/advena/beetle_1176_1088.png</td>\n",
+       "      <td>separate segmented splits</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>beetle_414_629.png</td>\n",
+       "      <td>3f388c96812cbfcf6036939eae49afe0</td>\n",
+       "      <td>advena</td>\n",
+       "      <td>test</td>\n",
+       "      <td>test/advena/beetle_414_629.png</td>\n",
+       "      <td>separate segmented splits</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>beetle_339_946.png</td>\n",
+       "      <td>df7b91b86ee4dc3b0ee8e8000f8b6e18</td>\n",
+       "      <td>advena</td>\n",
+       "      <td>test</td>\n",
+       "      <td>test/advena/beetle_339_946.png</td>\n",
+       "      <td>separate segmented splits</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>beetle_130_537.png</td>\n",
+       "      <td>debd1c10ff568fd9ea48a025808cc324</td>\n",
+       "      <td>advena</td>\n",
+       "      <td>test</td>\n",
+       "      <td>test/advena/beetle_130_537.png</td>\n",
+       "      <td>separate segmented splits</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>beetle_320_1374.png</td>\n",
+       "      <td>87d5a67d7f6ac04882ea9ab96e21272f</td>\n",
+       "      <td>advena</td>\n",
+       "      <td>test</td>\n",
+       "      <td>test/advena/beetle_320_1374.png</td>\n",
+       "      <td>separate segmented splits</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               filename                               md5 species split  \\\n",
+       "0  beetle_1176_1088.png  dcd4b79619ac96fd7519225f3bd46a86  advena  test   \n",
+       "1    beetle_414_629.png  3f388c96812cbfcf6036939eae49afe0  advena  test   \n",
+       "2    beetle_339_946.png  df7b91b86ee4dc3b0ee8e8000f8b6e18  advena  test   \n",
+       "3    beetle_130_537.png  debd1c10ff568fd9ea48a025808cc324  advena  test   \n",
+       "4   beetle_320_1374.png  87d5a67d7f6ac04882ea9ab96e21272f  advena  test   \n",
+       "\n",
+       "                          file_name                     subset  \n",
+       "0  test/advena/beetle_1176_1088.png  separate segmented splits  \n",
+       "1    test/advena/beetle_414_629.png  separate segmented splits  \n",
+       "2    test/advena/beetle_339_946.png  separate segmented splits  \n",
+       "3    test/advena/beetle_130_537.png  separate segmented splits  \n",
+       "4   test/advena/beetle_320_1374.png  separate segmented splits  "
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[list(df.columns)[1:]].head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df[list(df.columns)[1:]].to_csv(\"../../2018-NEON-beetles/Separate_segmented_train_test_splits_80_20/metadata.csv\", index = False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py:percent"
+  },
+  "kernelspec": {
+   "display_name": "std",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/Separate_segmented_splits_meta_gen.py
+++ b/notebooks/Separate_segmented_splits_meta_gen.py
@@ -1,0 +1,84 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.0
+#   kernelspec:
+#     display_name: std
+#     language: python
+#     name: python3
+# ---
+
+# %%
+import pandas as pd
+
+# %% [markdown]
+# # Get Metadata for [Separate_segmented_train_test_splits_80_20](https://huggingface.co/datasets/imageomics/2018-NEON-beetles/tree/main/Separate_segmented_train_test_splits_80_20)
+#
+# Using [`sum-buddy`](https://github.com/Imageomics/sum-buddy) package within the [2018-NEON-beetles repository](https://huggingface.co/datasets/imageomics/2018-NEON-beetles):
+# ```
+# sum-buddy -o Separate_segmented_train_test_splits_80_20/checksum_metadata.csv Separate_segmented_train_test_splits_80_20
+# ```
+
+# %%
+df = pd.read_csv("../../2018-NEON-beetles/Separate_segmented_train_test_splits_80_20/checksum_metadata.csv")
+df.head()
+
+# %% [markdown]
+# ## Make `split`, `species`, and `file_name` Columns
+#
+# `file_name` will be path within the `Separate_segmented_train_test_splits_80_20` for the dataset viewer on HF (and we'll name the file `metadata.csv` at that point).
+
+# %%
+df["filepath"].values[:10]
+
+
+# %%
+def get_split(filepath):
+    return filepath.split("/")[1]
+
+def get_species(filepath):
+    return filepath.split("/")[2]
+
+def get_file_name(filepath):
+    return filepath.split("splits_80_20/")[1]
+
+
+# %%
+df["species"] = df["filepath"].apply(get_species)
+df["split"] = df["filepath"].apply(get_split)
+df["file_name"] = df["filepath"].apply(get_file_name)
+
+df["subset"] = "separate segmented splits"
+
+# %%
+df.head()
+
+# %%
+df.species.value_counts()
+
+# %% [markdown]
+# ## Display Distribution
+
+# %%
+import seaborn as sns
+
+# %%
+sns.histplot(df.sort_values("species"), y = "species", hue = "split")
+
+# %% [markdown]
+# ## Save CSV
+#
+# We don't need the `filepath` column since we're including the `file_name` for the purpose of the dataset viewer.
+
+# %%
+df[list(df.columns)[1:]].head()
+
+# %%
+df[list(df.columns)[1:]].to_csv("../../2018-NEON-beetles/Separate_segmented_train_test_splits_80_20/metadata.csv", index = False)
+
+# %%


### PR DESCRIPTION
Adding the notebook used to generate a metadata file (for dataset viewer) for [Separate segmented split](https://huggingface.co/datasets/imageomics/2018-NEON-beetles/tree/main/Separate_segmented_train_test_splits_80_20), the data generated in the notebook from #11. See [HF discussion 18](https://huggingface.co/datasets/imageomics/2018-NEON-beetles/discussions/18).