### PR TITLE
Add segmentation notebook description

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,11 +6,14 @@ authors:
 - family-names: Nepovinnykh
   given-names: Ekaterina
   orcid: "https://orcid.org/0000-0002-5045-5041"
+- family-names: Ali
+  given-names: Sarwan
+  orcid: "https://orcid.org/0000-0001-8121-2168"
 - family-names: Campolongo
   given-names: "Elizabeth G."
   orcid: "https://orcid.org/0000-0003-0846-2413"
 cff-version: 1.2.0
-date-released: "2024-08-12"
+date-released: "2025-08-28"
 keywords:
   - imageomics
   - biology
@@ -27,7 +30,7 @@ license: MIT
 message: "If you find this software helpful in your research, please cite both the software and data."
 repository-code: "https://github.com/Imageomics/2018-NEON-beetles-processing"
 title: "2018 NEON Ethanol-preserved Ground Beetles Processing"
-version: 1.0.0
+version: 2.0.0
 #doi: <DOI from Zenodo>
 type: software
 references:
@@ -45,6 +48,6 @@ references:
     title: "2018 NEON Ethanol-preserved Ground Beetles"
     #version:
     type: dataset
-    #doi: 
+    doi: "10.57967/hf/5252"
     url: "https://huggingface.co/datasets/imageomics/2018-NEON-beetles"
-    date-released: 2024
+    date-released: 2025

--- a/notebooks/Beetle_Palooza_image_separation.ipynb
+++ b/notebooks/Beetle_Palooza_image_separation.ipynb
@@ -13,6 +13,32 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "294d146e",
+   "metadata": {},
+   "source": [
+    "# Segmentation Notebook\n",
+    "\n",
+    "This notebook was used to generate the [Separate Segmented train-test split subset](https://huggingface.co/datasets/imageomics/2018-NEON-beetles/tree/main/Separate_segmented_train_test_splits_80_20) of the [2018 NEON Ethanol-preserved Ground Beetles Dataset](https://huggingface.co/datasets/imageomics/2018-NEON-beetles). It was part of a project at [BeetlePalooza 2024](https://doi.org/10.5281/zenodo.15540300). The method employed here is distinct from that used in the [segmentation directory](../segmentation/) of this repository (that method is also explained in the [repo README](../README.md)). This method uses [OpenCV thresholding](https://opencv24-python-tutorials.readthedocs.io/en/latest/py_tutorials/py_imgproc/py_thresholding/py_thresholding.html) to distinguish beetles in the image, specifically, this is used to determine contours, within which the number of blue pixels is measured, and a beetle is determined to be in there if that count does not exceed a particular threshold.\n",
+    "\n",
+    "This notebook generates individual images for approximately 7,000 beetles from the following species (not really 12 species: repeated species epithet in _Pterostichus melanarius melanarius_ indicates this is the nominotypical subspecies of _Pterostichus melanarius_).\n",
+    "1. _Calathus advena_\n",
+    "2. _Cyclotrachelus torvus_\n",
+    "3. _Chlaenius aestivus_\n",
+    "4. _Euryderus grossus_\n",
+    "5. _Harpalus pensylvanicus_ OR _Pterostichus pensylvanicus_ --- this species epithet seems to have two different genera associated to it and will thus require more effort for alignment. Hopefully, it's just a matter of merging on an ID from the original dataset but look at the filename generation to figure it out.\n",
+    "6. _Pterostichus melanarius_\n",
+    "7. _Pterostichus restrictus_\n",
+    "8.  _Pterostichus melanarius melanarius_  —  nominotypical subspecies of _Pterostichus melanarius_\n",
+    "9.  _Pterostichus lachrymosus_\n",
+    "10.  _Carabus goryi_\n",
+    "11.  _Cratacanthus dubius_\n",
+    "12.  _Synuchus impunctatus_\n",
+    "\n",
+    "For more information on the distribution of species, please see the [metadata generation notebook](Separate_segmented_splits_meta_gen.ipynb)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 55,
    "id": "a2b6a7da",


### PR DESCRIPTION
Adds description of the methods and content to the top of @sarwanpasha's segmentation notebook. Also adds @sarwanpasha to the `CITATION.cff`, increments version to 2.0.0, and adds DOI ref for the beetle dataset.