### PR TITLE
Add DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -31,7 +31,7 @@ message: "If you find this software helpful in your research, please cite both t
 repository-code: "https://github.com/Imageomics/2018-NEON-beetles-processing"
 title: "2018 NEON Ethanol-preserved Ground Beetles Processing"
 version: 2.0.0
-#doi: <DOI from Zenodo>
+doi: "10.5281/zenodo.16989738"
 type: software
 references:
   - authors:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BeetlePalooza Dataset Code
+# BeetlePalooza Dataset Code  [![DOI](https://zenodo.org/badge/839423337.svg)](https://doi.org/10.5281/zenodo.16989737)
 
 This repository hosts the code and notebooks used to explore and process the [BeetlePalooza](https://github.com/Imageomics/BeetlePalooza-2024/wiki) dataset: [2018 NEON Ethanol-preserved Ground Beetles](https://huggingface.co/datasets/imageomics/2018-NEON-beetles).
 


### PR DESCRIPTION
Adds the DOI to the citation, and adds the DOI badge to the README.

In this case, I didn't use the general DOI in the `CITATION.cff` since I don't think this repository is going to be updated any further at this point, so it would remain the version-specific DOI.